### PR TITLE
Fix cpp implementations

### DIFF
--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -675,7 +675,7 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
         if YesNoDefault.test_truth(YesNoDefault.DEFAULT, language.enable_stropping):
             return language.filter_id(t.short_name)
         else:
-            return t.short_name
+            return str(t.short_name)
     return language.filter_short_reference_name(t)
 
 

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -671,7 +671,7 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
 
     :param pydsdl.CompositeType t: The DSDL type to get the reference name for.
     """
-    if isinstance(t, pydsdl.ServiceType) :
+    if isinstance(t, pydsdl.ServiceType):
         if YesNoDefault.test_truth(YesNoDefault.DEFAULT, language.enable_stropping):
             return language.filter_id(t.short_name)
         else:

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -21,6 +21,7 @@ from ...templates import template_language_filter, template_language_list_filter
 from .. import Dependencies
 from .. import Language as BaseLanguage
 from .._common import IncludeGenerator, TokenEncoder, UniqueNameGenerator
+from ..._utilities import YesNoDefault
 from ..c import _CFit
 from ..c import filter_literal as c_filter_literal
 
@@ -587,6 +588,7 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
         my_type = MagicMock(spec=pydsdl.StructureType)
         my_type.version = MagicMock()
         my_type.parent_service = None
+        my_type.has_parent_service = False
 
     .. code-block:: python
 
@@ -608,10 +610,11 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
         my_type = MagicMock(spec=pydsdl.StructureType)
         my_type.version = MagicMock()
         my_type.parent_service = None
+        my_type.has_parent_service = False
 
     .. code-block:: python
 
-        # Given a type with illegal C++ characters
+        # Given a type with legal C++ characters
         my_type.short_name = 'Struct_'
         my_type.version.major = 0
         my_type.version.minor = 1
@@ -626,12 +629,53 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
 
         jinja_filter_tester(filter_short_reference_name, template, rendered, 'cpp', my_type=my_type)
 
-        my_type = MagicMock(spec=pydsdl.StructureType)
-        my_type.version = MagicMock()
-        my_type.parent_service = None
+    .. invisible-code-block: python
+        my_service_type = MagicMock(spec=pydsdl.ServiceType)
+        my_service_type.version = MagicMock()
+        my_service_type.parent_service = None
+        my_service_type.has_parent_service = False
+        my_service_type.request_type = MagicMock(spec=pydsdl.StructureType)
+        my_service_type.request_type.has_parent_service = True
+        my_service_type.request_type.short_name = "Request"
+        my_service_type.request_type.version = my_service_type.version
+        my_service_type.request_type.parent_service = my_service_type
+        my_service_type.response_type = MagicMock(spec=pydsdl.StructureType)
+        my_service_type.response_type.has_parent_service = True
+        my_service_type.response_type.short_name = "Response"
+        my_service_type.response_type.version = my_service_type.version
+        my_service_type.response_type.parent_service = my_service_type
+
+    .. code-block:: python
+
+        # Given a service type
+        my_service_type.short_name = 'Struct_'
+        my_service_type.version.major = 0
+        my_service_type.version.minor = 1
+
+        # and
+        template = '''
+        {{ my_service_type | short_reference_name }}
+        {{ my_service_type.request_type | short_reference_name }}
+        {{ my_service_type.response_type | short_reference_name }}
+        '''
+
+        # then, with stropping enabled
+        rendered = '''
+        Struct_
+        Request_0_1
+        Response_0_1
+        '''
+
+    .. invisible-code-block: python
+        jinja_filter_tester(filter_short_reference_name, template, rendered, 'cpp', my_service_type=my_service_type)
 
     :param pydsdl.CompositeType t: The DSDL type to get the reference name for.
     """
+    if isinstance(t, pydsdl.ServiceType) :
+        if YesNoDefault.test_truth(YesNoDefault.DEFAULT, language.enable_stropping):
+            return language.filter_id(t.short_name)
+        else:
+            return t.short_name
     return language.filter_short_reference_name(t)
 
 
@@ -728,6 +772,7 @@ def filter_definition_begin(language: Language, instance: pydsdl.CompositeType) 
         my_type = MagicMock(spec=pydsdl.StructureType)
         my_type.version = MagicMock()
         my_type.parent_service = None
+        my_type.has_parent_service = False
 
         with pytest.raises(ValueError):
             jinja_filter_tester(filter_definition_begin,
@@ -756,6 +801,7 @@ def filter_definition_begin(language: Language, instance: pydsdl.CompositeType) 
         my_union_type = MagicMock(spec=pydsdl.UnionType)
         my_union_type.version = MagicMock()
         my_union_type.parent_service = None
+        my_union_type.has_parent_service = False
 
     .. code-block:: python
 
@@ -777,6 +823,17 @@ def filter_definition_begin(language: Language, instance: pydsdl.CompositeType) 
         my_service_type = MagicMock(spec=pydsdl.ServiceType)
         my_service_type.version = MagicMock()
         my_service_type.parent_service = None
+        my_service_type.has_parent_service = False
+        my_service_type.request_type = MagicMock(spec=pydsdl.StructureType)
+        my_service_type.request_type.short_name = "Request"
+        my_service_type.request_type.version = my_service_type.version
+        my_service_type.request_type.parent_service = my_service_type
+        my_service_type.request_type.has_parent_service = True
+        my_service_type.response_type = MagicMock(spec=pydsdl.StructureType)
+        my_service_type.response_type.short_name = "Response"
+        my_service_type.response_type.version = my_service_type.version
+        my_service_type.response_type.parent_service = my_service_type
+        my_service_type.response_type.has_parent_service = True
 
     .. code-block:: python
 
@@ -786,17 +843,25 @@ def filter_definition_begin(language: Language, instance: pydsdl.CompositeType) 
         my_service_type.version.minor = 0
 
         # and
-        template = '{{ my_service_type | definition_begin }}'
+        template = '''
+        {{ my_service_type | definition_begin }};
+        {{ my_service_type.request_type | definition_begin }};
+        {{ my_service_type.response_type | definition_begin }};
+        '''
 
         # then
-        rendered = 'namespace Foo_1_0'
+        rendered = '''
+        namespace Foo;
+        struct Request_1_0;
+        struct Response_1_0;
+        '''
 
     .. invisible-code-block: python
 
         jinja_filter_tester(filter_definition_begin, template, rendered, 'cpp', my_service_type=my_service_type)
 
     """
-    short_name = language.filter_short_reference_name(instance)
+    short_name = filter_short_reference_name(language, instance)
     if (
         isinstance(instance, pydsdl.DelimitedType)
         or isinstance(instance, pydsdl.StructureType)

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -76,12 +76,12 @@ namespace nunavut
 namespace support
 {
 
-
 template<typename T>
 class span{
     T* ptr_;
     {{ typename_unsigned_length }} size_;
 public:
+    using value_type = T;
     template<{{ typename_unsigned_length }} N>
     span(std::array<T, N>& data): ptr_(data.data()), size_(data.size()){}
     template<{{ typename_unsigned_length }} N>
@@ -154,7 +154,16 @@ public:
         else { new(error_ptr()) Error(*other.error_ptr()); }
     }
     expected& operator=(const expected& other){
-        this->~expected(); return *new(this) expected(other);
+        this->~expected();
+        return *new(this) expected(other);
+    }
+    expected(expected&& other): is_expected_(other.is_expected_){
+        if(is_expected_){ new(ret_ptr()) Ret(std::move(*other.ret_ptr())); }
+        else { new(error_ptr()) Error(std::move(*other.error_ptr())); }
+    }
+    expected& operator=(expected&& other){
+        this->~expected();
+        return *new(this) expected(std::move(other));
     }
     ~expected(){
         if(is_expected_){ ret_ptr()->~Ret(); }
@@ -217,9 +226,10 @@ protected:
         return self.data_.data() + offset_bytes;
     }
 public:
+
     derived_bitspan at_offset({{ typename_unsigned_bit_length }} bits) const noexcept {
         auto& self  = *static_cast<const derived_bitspan*>(this);
-        return derived_bitspan(self.data_, self.offset_bits_ + bits);
+        return derived_bitspan(self.data_.data(), self.data_.size(), self.offset_bits_ + bits);
     }
 
     /// Create a copy of current bitspan, converting current offset into  pointer
@@ -234,7 +244,7 @@ public:
         const {{ typename_unsigned_bit_length }} offset_bits_mod = (offset_bits) % 8U;
         const {{ typename_unsigned_length }} newSize = {# -#}
             (offset_bytes < self.data_.size())?(self.data_.size() - offset_bytes):(0U);
-        return derived_bitspan({self.data_.data() + offset_bytes, newSize}, offset_bits_mod);
+        return derived_bitspan(self.data_.data() + offset_bytes, newSize, offset_bits_mod);
     }
 
     void add_offset({{ typename_unsigned_bit_length }} bits) noexcept{
@@ -320,9 +330,22 @@ private:
     bytespan data_;
     {{ typename_unsigned_bit_length }} offset_bits_;
 public:
-    bitspan(bytespan data, {{ typename_unsigned_bit_length }} offset_bits=0)
-        :data_(std::move(data)), offset_bits_(offset_bits){
-    }
+    using value_type = typename bytespan::value_type;
+
+    template<{{ typename_unsigned_length }} N>
+    bitspan(std::array<value_type, N>& data, {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(data.data(), data.size()), offset_bits_(offset_bits) {}
+
+    template<{{ typename_unsigned_length }} N>
+    bitspan(const std::array<value_type, N>& data, {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(data.data(), data.size()), offset_bits_(offset_bits) {}
+
+    template<{{ typename_unsigned_length }} N>
+    bitspan(value_type (&data)[N], {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(data, N), offset_bits_(offset_bits) {}
+
+    bitspan(value_type* ptr,  {{ typename_unsigned_length }} size, {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(ptr, size), offset_bits_(offset_bits) {}
 
     Result<bitspan> subspan({# -#}
         {{ typename_unsigned_bit_length }} bits_at, {{ typename_unsigned_bit_length }} size_bits) const noexcept;
@@ -358,9 +381,22 @@ private:
     const_bytespan data_;
     {{ typename_unsigned_bit_length }} offset_bits_;
 public:
-    const_bitspan(const_bytespan data, {{ typename_unsigned_bit_length }} offset_bits=0)
-        :data_(std::move(data)), offset_bits_(offset_bits){
-    }
+    using value_type = typename const_bytespan::value_type;
+
+    template<{{ typename_unsigned_length }} N>
+    const_bitspan(std::array<value_type, N>& data, {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(data.data(), data.size()), offset_bits_(offset_bits) {}
+
+    template<{{ typename_unsigned_length }} N>
+    const_bitspan(const std::array<value_type, N>& data, {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(data.data(), data.size()), offset_bits_(offset_bits) {}
+
+    template<{{ typename_unsigned_length }} N>
+    const_bitspan(value_type (&data)[N], {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(data, N), offset_bits_(offset_bits) {}
+
+    const_bitspan(value_type* ptr,  {{ typename_unsigned_length }} size, {{ typename_unsigned_bit_length }} offset_bits=0)
+        : data_(ptr, size), offset_bits_(offset_bits) {}
 
 
     /// Copy the specified number of bits from the source buffer into the destination buffer in accordance with the
@@ -486,7 +522,7 @@ public:
         // Apply implicit zero extension. Normally, this is a no-op unless (len_bits > sat_bits) or (len_bits % 8 != 0).
         // The former case ensures that if we're copying <8 bits, the MSB in the destination will be zeroed out.
         std::memset(output.data() + (sat_bits / 8U), 0, len_bytes - (sat_bits / 8U));
-        copyTo(bitspan{output, 0U}, sat_bits);
+        copyTo(bitspan{output.data(), output.size(), 0U}, sat_bits);
     }
 
 
@@ -582,7 +618,7 @@ inline Result<bitspan> bitspan::subspan({# -#}
         return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
     }
     const {{ typename_unsigned_length }} new_size_bytes = new_size_bits / 8U;
-    return bitspan({ data_.data() + offset_bytes, new_size_bytes }, new_offset_bits);
+    return bitspan( data_.data() + offset_bytes, new_size_bytes, new_offset_bits);
 }
 
 
@@ -593,7 +629,7 @@ inline uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
     const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 8U));
     {{ assert('bits <= (sizeof(uint8_t) * 8U)') }}
     uint8_t val = 0;
-    copyTo(bitspan{ { &val, 1U } }, bits);
+    copyTo(bitspan{ &val, 1U }, bits);
     return val;
 }
 
@@ -604,11 +640,11 @@ inline uint16_t const_bitspan::getU16(const uint8_t len_bits) const noexcept
     {{ assert('bits <= (sizeof(uint16_t) * 8U)') }}
 {%- if options.target_endianness == 'little' %}
     uint16_t val = 0U;
-    copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+    copyTo(bitspan{ reinterpret_cast<uint8_t*>(&val), sizeof(val) }, bits);
     return val;
 {%- elif options.target_endianness in ('any', 'big') %}
     uint8_t tmp[sizeof(uint16_t)] = {0};
-    copyTo(bitspan{ { &tmp[0], sizeof(tmp) } }, bits);
+    copyTo(tmp, bits);
     return static_cast<uint16_t>(static_cast<uint16_t>(tmp[0]) | ((static_cast<uint16_t>(tmp[1])) << 8U));
 {%- else %}{%- assert False %}
 {%- endif %}
@@ -621,11 +657,11 @@ inline uint32_t const_bitspan::getU32(const uint8_t len_bits) const noexcept
     {{ assert('bits <= (sizeof(uint32_t) * 8U)') }}
 {%- if options.target_endianness == 'little' %}
     uint32_t val = 0U;
-    copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+    copyTo(bitspan{ reinterpret_cast<uint8_t*>(&val), sizeof(val) }, bits);
     return val;
 {%- elif options.target_endianness in ('any', 'big') %}
     uint8_t tmp[sizeof(uint32_t)] = {0};
-    copyTo(bitspan{ { tmp, sizeof(tmp) } }, bits);
+    copyTo(tmp, bits);
     return static_cast<uint32_t>(
         (static_cast<uint32_t>(tmp[0])) |
         (static_cast<uint32_t>(tmp[1]) << 8U) |
@@ -642,11 +678,11 @@ inline uint64_t const_bitspan::getU64(const uint8_t len_bits) const noexcept
     {{ assert('bits <= (sizeof(uint64_t) * 8U)') }}
 {%- if options.target_endianness == 'little' %}
     uint64_t val = 0U;
-    copyTo(bitspan{ { reinterpret_cast<uint8_t*>(&val), sizeof(val) } }, bits);
+    copyTo(bitspan{ reinterpret_cast<uint8_t*>(&val), sizeof(val) }, bits);
     return val;
 {%- elif options.target_endianness in ('any', 'big') %}
     uint8_t tmp[sizeof(uint64_t)] = {0};
-    copyTo(bitspan{ { tmp, sizeof(tmp) } }, bits);
+    copyTo(tmp, bits);
     return static_cast<uint64_t>(static_cast<uint64_t>(tmp[0]) |
                     (static_cast<uint64_t>(tmp[1]) << 8U) |
                     (static_cast<uint64_t>(tmp[2]) << 16U) |
@@ -702,7 +738,7 @@ inline VoidResult bitspan::setBit(const bool value)
         return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
     }
     const uint8_t val = value ? 1U : 0U;
-    const_bitspan{ { &val, 1U } }.copyTo(*this, 1U);
+    const_bitspan{ &val, 1U }.copyTo(*this, 1U);
     return {};
 }
 
@@ -716,9 +752,9 @@ inline VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
     const {{ typename_unsigned_bit_length }} saturated_len_bits = std::min<{{ typename_unsigned_bit_length }}>({# -#}
         len_bits, 64U);
 {%- if options.target_endianness == 'little' %}
-        bitspan{ { reinterpret_cast<const uint8_t*>(&value), sizeof(uint64_t) } }.copyTo(*this, saturated_len_bits);
+        bitspan{ reinterpret_cast<const uint8_t*>(&value), sizeof(uint64_t) }.copyTo(*this, saturated_len_bits);
 {%- elif options.target_endianness in ('any', 'big') %}
-    std::array<uint8_t, 8> tmp{
+    const std::array<const uint8_t, 8> tmp{
         static_cast<uint8_t>((value >> 0U) & 0xFFU),
         static_cast<uint8_t>((value >> 8U) & 0xFFU),
         static_cast<uint8_t>((value >> 16U) & 0xFFU),
@@ -728,7 +764,7 @@ inline VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
         static_cast<uint8_t>((value >> 48U) & 0xFFU),
         static_cast<uint8_t>((value >> 56U) & 0xFFU),
     };
-    const_bitspan{ { &tmp[0], sizeof(uint64_t) } }.copyTo(*this, saturated_len_bits);
+    const_bitspan{ tmp }.copyTo(*this, saturated_len_bits);
 {%- else %}{%- assert False %}
 {%- endif %}
     return {};

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -534,7 +534,7 @@ public:
     {{ typename_float_64 }} getF64();
 };
 
-VoidResult bitspan::setZeros({{ typename_unsigned_bit_length }} length){
+inline VoidResult bitspan::setZeros({{ typename_unsigned_bit_length }} length){
     if(length > size()){
         return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
     }
@@ -551,7 +551,7 @@ VoidResult bitspan::setZeros({{ typename_unsigned_bit_length }} length){
     return {};
 }
 
-VoidResult bitspan::padAndMoveToAlignment({{ typename_unsigned_bit_length }} n_bits){
+inline VoidResult bitspan::padAndMoveToAlignment({{ typename_unsigned_bit_length }} n_bits){
     const auto padding = static_cast<uint8_t>(n_bits - offset_misalignment(n_bits));
     if (padding != n_bits)  // Pad to n_bits bits. TODO: Eliminate redundant padding checks.
     {
@@ -567,7 +567,7 @@ VoidResult bitspan::padAndMoveToAlignment({{ typename_unsigned_bit_length }} n_b
 }
 
 
-Result<bitspan> bitspan::subspan({# -#}
+inline Result<bitspan> bitspan::subspan({# -#}
         {{ typename_unsigned_bit_length }} bits_at, {{ typename_unsigned_bit_length }} size_bits) const noexcept {
     const {{ typename_unsigned_bit_length }} offset_bits = offset_bits_ + bits_at;
     const {{ typename_unsigned_length }} offset_bytes = offset_bits / 8U;
@@ -587,7 +587,7 @@ Result<bitspan> bitspan::subspan({# -#}
 
 
 
-uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
+inline uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
 {
     {{ assert('data_.data() != nullptr') }}
     const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 8U));
@@ -597,7 +597,7 @@ uint8_t const_bitspan::getU8(const uint8_t len_bits) const noexcept
     return val;
 }
 
-uint16_t const_bitspan::getU16(const uint8_t len_bits) const noexcept
+inline uint16_t const_bitspan::getU16(const uint8_t len_bits) const noexcept
 {
     {{ assert('data_.data() != nullptr') }}
     const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 16U));
@@ -614,7 +614,7 @@ uint16_t const_bitspan::getU16(const uint8_t len_bits) const noexcept
 {%- endif %}
 }
 
-uint32_t const_bitspan::getU32(const uint8_t len_bits) const noexcept
+inline uint32_t const_bitspan::getU32(const uint8_t len_bits) const noexcept
 {
     {{ assert('data_.data() != nullptr') }}
     const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 32U));
@@ -635,7 +635,7 @@ uint32_t const_bitspan::getU32(const uint8_t len_bits) const noexcept
 {%- endif %}
 }
 
-uint64_t const_bitspan::getU64(const uint8_t len_bits) const noexcept
+inline uint64_t const_bitspan::getU64(const uint8_t len_bits) const noexcept
 {
     {{ assert('data_.data() != nullptr') }}
     const {{ typename_unsigned_bit_length }} bits = saturateBufferFragmentBitLength(std::min<uint8_t>(len_bits, 64U));
@@ -659,7 +659,7 @@ uint64_t const_bitspan::getU64(const uint8_t len_bits) const noexcept
 {%- endif %}
 }
 
-int8_t const_bitspan::getI8(const uint8_t len_bits) const noexcept
+inline int8_t const_bitspan::getI8(const uint8_t len_bits) const noexcept
 {
     const uint8_t sat = std::min<uint8_t>(len_bits, 8U);
     uint8_t       val = getU8(sat);
@@ -668,7 +668,7 @@ int8_t const_bitspan::getI8(const uint8_t len_bits) const noexcept
     return neg ? static_cast<int8_t>(-static_cast<int8_t>(static_cast<uint8_t>(~val)) - 1) : static_cast<int8_t>(val);
 }
 
-int16_t const_bitspan::getI16(const uint8_t len_bits) const noexcept
+inline int16_t const_bitspan::getI16(const uint8_t len_bits) const noexcept
 {
     const uint8_t sat = std::min<uint8_t>(len_bits, 16U);
     uint16_t      val = getU16(sat);
@@ -677,7 +677,7 @@ int16_t const_bitspan::getI16(const uint8_t len_bits) const noexcept
     return neg ? static_cast<int16_t>(-static_cast<int16_t>(static_cast<uint16_t>(~val)) - 1) : static_cast<int16_t>(val);
 }
 
-int32_t const_bitspan::getI32(const uint8_t len_bits) const noexcept
+inline int32_t const_bitspan::getI32(const uint8_t len_bits) const noexcept
 {
     const uint8_t sat = std::min<uint8_t>(len_bits, 32U);
     uint32_t      val = getU32(sat);
@@ -686,7 +686,7 @@ int32_t const_bitspan::getI32(const uint8_t len_bits) const noexcept
     return neg ? static_cast<int32_t>((-static_cast<int32_t>(~val)) - 1) : static_cast<int32_t>(val);
 }
 
-int64_t const_bitspan::getI64(const uint8_t len_bits) const noexcept
+inline int64_t const_bitspan::getI64(const uint8_t len_bits) const noexcept
 {
     const uint8_t sat = std::min<uint8_t>(len_bits, 64U);
     uint64_t      val = getU64(sat);
@@ -695,7 +695,7 @@ int64_t const_bitspan::getI64(const uint8_t len_bits) const noexcept
     return neg ? static_cast<int64_t>((-static_cast<int64_t>(~val)) - 1) : static_cast<int64_t>(val);
 }
 
-VoidResult bitspan::setBit(const bool value)
+inline VoidResult bitspan::setBit(const bool value)
 {
     if ((data_.size() * 8U) <= offset_bits_)
     {
@@ -706,7 +706,7 @@ VoidResult bitspan::setBit(const bool value)
     return {};
 }
 
-VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
+inline VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
 {
     static_assert(64U == (sizeof(uint64_t) * 8U), "Unexpected size of uint64_t");
     if ((data_.size() * 8) < (offset_bits_ + len_bits))
@@ -734,7 +734,7 @@ VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
     return {};
 }
 
-VoidResult bitspan::setIxx(const int64_t value, const uint8_t len_bits)
+inline VoidResult bitspan::setIxx(const int64_t value, const uint8_t len_bits)
 {
     // The naive sign conversion is safe and portable according to the C++ Standard 4.7/2 :
     // If the destination type is unsigned, the resulting value is the least unsigned integer
@@ -817,12 +817,12 @@ static inline {{typename_float_32}} float16Unpack(const uint16_t value)
     return out.real;
 }
 
-VoidResult bitspan::setF16(const {{ typename_float_32 }} value)
+inline VoidResult bitspan::setF16(const {{ typename_float_32 }} value)
 {
     return setUxx(float16Pack(value), 16U);
 }
 
-{{typename_float_32}} const_bitspan::getF16()
+inline {{typename_float_32}} const_bitspan::getF16()
 {
     return float16Unpack(getU16(16U));
 }
@@ -833,7 +833,7 @@ static_assert(NUNAVUT_PLATFORM_IEEE754_FLOAT,
               "The target platform does not support IEEE754 floating point operations.");
 static_assert(32U == (sizeof({{typename_float_32}}) * 8U), "Unsupported floating point model");
 
-VoidResult bitspan::setF32(const {{ typename_float_32 }} value)
+inline VoidResult bitspan::setF32(const {{ typename_float_32 }} value)
 {
     // Intentional violation of MISRA: use union to perform fast conversion from an IEEE 754-compatible native
     // representation into a serializable integer. The assumptions about the target platform properties are made
@@ -846,7 +846,7 @@ VoidResult bitspan::setF32(const {{ typename_float_32 }} value)
     return setUxx(tmp.in, sizeof(tmp) * 8U);
 }
 
-{{typename_float_32}} const_bitspan::getF32()
+inline {{typename_float_32}} const_bitspan::getF32()
 {
     // Intentional violation of MISRA: use union to perform fast conversion to an IEEE 754-compatible native
     // representation into a serializable integer. The assumptions about the target platform properties are made
@@ -865,7 +865,7 @@ static_assert(NUNAVUT_PLATFORM_IEEE754_DOUBLE,
               "The target platform does not support IEEE754 double-precision floating point operations.");
 static_assert(64U == (sizeof({{typename_float_64}}) * 8U), "Unsupported floating point model");
 
-VoidResult bitspan::setF64(const {{typename_float_64 }} value)
+inline VoidResult bitspan::setF64(const {{typename_float_64 }} value)
 {
     // Intentional violation of MISRA: use union to perform fast conversion from an IEEE 754-compatible native
     // representation into a serializable integer. The assumptions about the target platform properties are made
@@ -878,7 +878,7 @@ VoidResult bitspan::setF64(const {{typename_float_64 }} value)
     return setUxx(tmp.in, sizeof(tmp) * 8U);
 }
 
-{{typename_float_64}} const_bitspan::getF64()
+inline {{typename_float_64}} const_bitspan::getF64()
 {
     // Intentional violation of MISRA: use union to perform fast conversion to an IEEE 754-compatible native
     // representation into a serializable integer. The assumptions about the target platform properties are made

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -77,7 +77,7 @@ namespace support
 {
 
 template<typename T>
-class span{
+class span final{
     T* ptr_;
     {{ typename_unsigned_length }} size_;
 public:
@@ -122,7 +122,7 @@ enum class Error{
 
 
 template<typename Err>
-struct unexpected{
+struct unexpected final{
     Err value;
     explicit unexpected(Err e):value(e){}
 };
@@ -132,7 +132,7 @@ struct unexpected{
 /// exceptional cases.
 /// All versions of Ret are expected to be non-throwing.
 template<typename Ret>
-class expected{
+class expected final{
     // We can use a maximum of all types.
     using storage_t = typename std::aligned_storage<
         (std::max(sizeof(Ret), sizeof(Error))),
@@ -184,7 +184,7 @@ public:
 };
 
 template<>
-class expected<void>{
+class expected<void> final{
     using underlying_type = typename std::underlying_type<Error>::type;
     underlying_type e;
 public:
@@ -323,7 +323,7 @@ public:
 
 } // namespace detail
 
-struct bitspan: public detail::any_bitspan<bitspan>{
+struct bitspan final: public detail::any_bitspan<bitspan>{
     friend struct detail::any_bitspan<bitspan>;
     friend struct const_bitspan;
 private:
@@ -375,7 +375,7 @@ public:
     VoidResult padAndMoveToAlignment({{ typename_unsigned_bit_length }} length);
 };
 
-struct const_bitspan: public detail::any_bitspan<const_bitspan>{
+struct const_bitspan final: public detail::any_bitspan<const_bitspan>{
     friend struct detail::any_bitspan<const_bitspan>;
 private:
     const_bytespan data_;

--- a/src/nunavut/lang/cpp/templates/ServiceType.j2
+++ b/src/nunavut/lang/cpp/templates/ServiceType.j2
@@ -12,5 +12,10 @@
 
 {% set composite_type = T.response_type %}{% include '_composite_type.j2' %}
 
+struct {{ 'Service_%s_%s' | format(T.version.major, T.version.minor) }} {
+    using Request = {{ T.request_type | short_reference_name }};
+    using Response = {{ T.response_type | short_reference_name }};
+};
+
 }{{ T | definition_end }}
 {%- endblock -%}

--- a/src/nunavut/lang/cpp/templates/ServiceType.j2
+++ b/src/nunavut/lang/cpp/templates/ServiceType.j2
@@ -13,6 +13,11 @@
 {% set composite_type = T.response_type %}{% include '_composite_type.j2' %}
 
 struct {{ 'Service_%s_%s' | format(T.version.major, T.version.minor) }} {
+    static constexpr bool IsServiceType = true;
+    static constexpr bool IsService = true;
+    static constexpr bool IsRequest = false;
+    static constexpr bool IsResponse = false;
+
     using Request = {{ T.request_type | short_reference_name }};
     using Response = {{ T.response_type | short_reference_name }};
 };

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -40,6 +40,14 @@
     /// This type does not have a fixed port-ID. See https://forum.opencyphal.org/t/choosing-message-and-service-ids/889
     static constexpr bool HasFixedPortID = false;
 {% endif -%}
+{%- if T is ServiceType %}
+    static constexpr bool IsServiceType = true;
+    static constexpr bool IsService = false;
+    static constexpr bool IsRequest = {{ (composite_type == T.request_type) | string | lower }};
+    static constexpr bool IsResponse = {{ (composite_type == T.response_type) | string | lower }};
+{%- else %}
+    static constexpr bool IsServiceType = false;
+{% endif -%}
     {%- assert composite_type.extent % 8 == 0 %}
     {%- assert composite_type.inner_type.extent % 8 == 0 %}
     /// Extent is the minimum amount of memory required to hold any serialized representation of any compatible

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -3,6 +3,7 @@
  # Copyright (C) 2021  UAVCAN Development Team  <uavcan.org>
  # This software is distributed under the terms of the MIT License.
 -#}
+{%- from '_definitions.j2' import assert -%}
 {%- ifuses "std_variant" %}
 // +-------------------------------------------------------------------------------------------------------------------+
 // | This implementation uses the C++17 standard library variant type with wrappers for the emplace and
@@ -84,6 +85,16 @@
 
     typename std::add_pointer<const {{ field.data_type | declaration }}>::type get_{{ field.name | id }}_if() const{
         return VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+    }
+
+    typename std::add_lvalue_reference<{{ field.data_type | declaration }}>::type get_{{ field.name | id }}(){
+        {{ assert('is_%s()' | format(field.name | id)) }}
+        return *VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+    }
+
+    typename std::add_lvalue_reference<const {{ field.data_type | declaration }}>::type get_{{ field.name | id }}() const{
+        {{ assert('is_%s()' | format(field.name | id)) }}
+        return *VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
     }
 
     template<class... Args> typename std::add_lvalue_reference<{{ field.data_type | declaration }}>::type

--- a/test/gentest_filters/test_filters.py
+++ b/test/gentest_filters/test_filters.py
@@ -259,7 +259,7 @@ def test_filter_full_reference_name_via_template(gen_paths, language_name, names
 
     assert json_blob is not None
     assert json_blob['parent']['full_reference_name'] == 'uavcan.str.bar_svc_1_0'.replace('.', namespace_separator)
-    assert json_blob['parent']['short_reference_name'] == 'bar_svc_1_0'
+    assert json_blob['parent']['short_reference_name'] == 'bar_svc' if language_name == 'cpp' else 'bar_svc_1_0'
     assert json_blob['request']['full_reference_name'] == 'uavcan.str.bar_svc.Request_1_0'.replace(
         '.', namespace_separator)
     assert json_blob['request']['short_reference_name'] == 'Request_1_0'

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -637,7 +637,7 @@ TEST(BitSpan, SetGetU8)
     {
         auto ref = randU8();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setUxx(ref, 8U);
+        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 8U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getU8(8U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -651,7 +651,7 @@ TEST(BitSpan, SetGetU16)
     {
         auto ref = randU16();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setUxx(ref, 16U);
+        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 16U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getU16(16U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -665,7 +665,7 @@ TEST(BitSpan, SetGetU32)
     {
         auto ref = randU32();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setUxx(ref, 32U);
+        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 32U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getU32(32U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -679,7 +679,7 @@ TEST(BitSpan, SetGetU64)
     {
         auto ref = randU64();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setUxx(ref, 64U);
+        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 64U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getU64(64U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -693,7 +693,7 @@ TEST(BitSpan, SetGetI8)
     {
         auto ref = randI8();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setIxx(ref, 8U);
+        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 8U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getI8(8U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -707,7 +707,7 @@ TEST(BitSpan, SetGetI16)
     {
         auto ref = randI16();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setIxx(ref, 16U);
+        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 16U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getI16(16U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -721,7 +721,7 @@ TEST(BitSpan, SetGetI32)
     {
         auto ref = randI32();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setIxx(ref, 32U);
+        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 32U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getI32(32U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
@@ -735,7 +735,7 @@ TEST(BitSpan, SetGetI64)
     {
         auto ref = randI64();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan({data}, offset).setIxx(ref, 64U);
+        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 64U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
         auto act = nunavut::support::const_bitspan(data, offset).getI64(64U);
         ASSERT_EQ(hex(ref), hex(act)) << i;

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -389,13 +389,13 @@ TEST(BitSpan, GetBit)
 TEST(BitSpan, GetU8)
 {
     const uint8_t data[] = {0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    ASSERT_EQ(0xFE, nunavut::support::const_bitspan(data, 0).getU8(8U));
+    ASSERT_EQ(0xFE, nunavut::support::const_bitspan(data).getU8(8U));
 }
 
 TEST(BitSpan, GetU8_tooSmall)
 {
     const uint8_t data[] = {0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    ASSERT_EQ(0x7F, nunavut::support::const_bitspan(data, 0).getU8(7U));
+    ASSERT_EQ(0x7F, nunavut::support::const_bitspan(data).getU8(7U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -405,13 +405,13 @@ TEST(BitSpan, GetU8_tooSmall)
 TEST(BitSpan, GetU16)
 {
     const uint8_t data[] = {0xAA, 0xAA};
-    ASSERT_EQ(0xAAAAU, nunavut::support::const_bitspan(data, 0).getU16(16U));
+    ASSERT_EQ(0xAAAAU, nunavut::support::const_bitspan(data).getU16(16U));
 }
 
 TEST(BitSpan, GetU16_tooSmall)
 {
     const uint8_t data[] = {0xAA, 0xAA};
-    ASSERT_EQ(0x0055U, nunavut::support::const_bitspan(data, 9).getU16(16U));
+    ASSERT_EQ(0x0055U, nunavut::support::const_bitspan(data, sizeof(data), 9).getU16(16U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -422,18 +422,18 @@ TEST(BitSpan, GetU32)
 {
     {
         const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA};
-        ASSERT_EQ(0xAAAAAAAAU, nunavut::support::const_bitspan(data, 0).getU32(32U));
+        ASSERT_EQ(0xAAAAAAAAU, nunavut::support::const_bitspan(data).getU32(32U));
     }
     {
         const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
-        ASSERT_EQ(0xFFFFFFFFU, nunavut::support::const_bitspan(data, 0).getU32(32U));
+        ASSERT_EQ(0xFFFFFFFFU, nunavut::support::const_bitspan(data).getU32(32U));
     }
 }
 
 TEST(BitSpan, GetU32_tooSmall)
 {
     const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA};
-    ASSERT_EQ(0x00555555U, nunavut::support::const_bitspan(data, 9).getU32(32U));
+    ASSERT_EQ(0x00555555U, nunavut::support::const_bitspan(data, sizeof(data), 9).getU32(32U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -444,18 +444,18 @@ TEST(BitSpan, GetU64)
 {
     {
         const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
-        ASSERT_EQ(0xAAAAAAAAAAAAAAAAU, nunavut::support::const_bitspan(data, 0).getU64(64U));
+        ASSERT_EQ(0xAAAAAAAAAAAAAAAAU, nunavut::support::const_bitspan(data).getU64(64U));
     }
     {
         const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-        ASSERT_EQ(0xFFFFFFFFFFFFFFFFU, nunavut::support::const_bitspan(data, 0).getU64(64U));
+        ASSERT_EQ(0xFFFFFFFFFFFFFFFFU, nunavut::support::const_bitspan(data).getU64(64U));
     }
 }
 
 TEST(BitSpan, GetU64_tooSmall)
 {
     const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
-    ASSERT_EQ(0x0055555555555555U, nunavut::support::const_bitspan(data, 9).getU64(64U));
+    ASSERT_EQ(0x0055555555555555U, nunavut::support::const_bitspan(data, sizeof(data), 9).getU64(64U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -465,25 +465,25 @@ TEST(BitSpan, GetU64_tooSmall)
 TEST(BitSpan, GetI8)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI8(8U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data).getI8(8U));
 }
 
 TEST(BitSpan, GetI8_tooSmall)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(127, nunavut::support::const_bitspan(data, 1).getI8(8U));
+    ASSERT_EQ(127, nunavut::support::const_bitspan(data, sizeof(data), 1).getI8(8U));
 }
 
 TEST(BitSpan, GetI8_tooSmallAndNegative)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI8(4U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, sizeof(data), 0).getI8(4U));
 }
 
 TEST(BitSpan, GetI8_zeroDataLen)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI8(0U));
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data, sizeof(data), 0).getI8(0U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -493,25 +493,25 @@ TEST(BitSpan, GetI8_zeroDataLen)
 TEST(BitSpan, GetI16)
 {
     const uint8_t data[] = {0xFF, 0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI16(16U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data).getI16(16U));
 }
 
 TEST(BitSpan, GetI16_tooSmall)
 {
     const uint8_t data[] = {0xFF, 0xFF};
-    ASSERT_EQ(32767, nunavut::support::const_bitspan(data, 1).getI16(16U));
+    ASSERT_EQ(32767, nunavut::support::const_bitspan(data, sizeof(data), 1).getI16(16U));
 }
 
 TEST(BitSpan, GetI16_tooSmallAndNegative)
 {
     const uint8_t data[] = {0xFF, 0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI16(12U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data).getI16(12U));
 }
 
 TEST(BitSpan, GetI16_zeroDataLen)
 {
     const uint8_t data[] = {0xFF, 0xFF};
-    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI16(0U));
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data).getI16(0U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -521,25 +521,25 @@ TEST(BitSpan, GetI16_zeroDataLen)
 TEST(BitSpan, GetI32)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI32(32U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data).getI32(32U));
 }
 
 TEST(BitSpan, GetI32_tooSmall)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(2147483647, nunavut::support::const_bitspan(data, 1).getI32(32U));
+    ASSERT_EQ(2147483647, nunavut::support::const_bitspan(data, sizeof(data), 1).getI32(32U));
 }
 
 TEST(BitSpan, GetI32_tooSmallAndNegative)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI32(20U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data).getI32(20U));
 }
 
 TEST(BitSpan, GetI32_zeroDataLen)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI32(0U));
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data).getI32(0U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -549,25 +549,25 @@ TEST(BitSpan, GetI32_zeroDataLen)
 TEST(BitSpan, GetI64)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI64(64U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, sizeof(data), 0).getI64(64U));
 }
 
 TEST(BitSpan, GetI64_tooSmall)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(9223372036854775807, nunavut::support::const_bitspan(data, 1).getI64(64U));
+    ASSERT_EQ(9223372036854775807, nunavut::support::const_bitspan(data, sizeof(data), 1).getI64(64U));
 }
 
 TEST(BitSpan, GetI64_tooSmallAndNegative)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, 0).getI64(60U));
+    ASSERT_EQ(-1, nunavut::support::const_bitspan(data, sizeof(data), 0).getI64(60U));
 }
 
 TEST(BitSpan, GetI64_zeroDataLen)
 {
     const uint8_t data[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    ASSERT_EQ(0, nunavut::support::const_bitspan(data, 0).getI64(0U));
+    ASSERT_EQ(0, nunavut::support::const_bitspan(data, sizeof(data), 0).getI64(0U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -577,49 +577,49 @@ TEST(BitSpan, GetI64_zeroDataLen)
 TEST(BitSpan, GetU8_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, 1U * 8U+1).getU8(8U));
+    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, sizeof(data), 1U * 8U+1).getU8(8U));
 }
 
 TEST(BitSpan, GetU16_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, 2U * 8U+1).getU16(16U));
+    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, sizeof(data), 2U * 8U+1).getU16(16U));
 }
 
 TEST(BitSpan, GetU32_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, 4U * 8U+1).getU32(32U));
+    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, sizeof(data), 4U * 8U+1).getU32(32U));
 }
 
 TEST(BitSpan, GetU64_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, 4U * 8U+1).getU64(64U));
+    ASSERT_EQ(0x0U, nunavut::support::const_bitspan(data, sizeof(data), 4U * 8U+1).getU64(64U));
 }
 
 TEST(BitSpan, GetI8_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, 1U * 8U+1).getI8(8U));
+    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, sizeof(data), 1U * 8U+1).getI8(8U));
 }
 
 TEST(BitSpan, GetI16_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, 2U * 8U+1).getI16(16U));
+    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, sizeof(data), 2U * 8U+1).getI16(16U));
 }
 
 TEST(BitSpan, GetI32_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, 4U * 8U+1).getI32(32U));
+    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, sizeof(data), 4U * 8U+1).getI32(32U));
 }
 
 TEST(BitSpan, GetI64_outofrange)
 {
     const uint8_t data[] = {0xFF};
-    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, 4U * 8U+1).getI64(64U));
+    ASSERT_EQ(0x0, nunavut::support::const_bitspan(data, sizeof(data), 4U * 8U+1).getI64(64U));
 }
 
 // +--------------------------------------------------------------------------+
@@ -637,9 +637,9 @@ TEST(BitSpan, SetGetU8)
     {
         auto ref = randU8();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 8U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setUxx(ref, 8U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getU8(8U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getU8(8U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -651,9 +651,9 @@ TEST(BitSpan, SetGetU16)
     {
         auto ref = randU16();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 16U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setUxx(ref, 16U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getU16(16U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getU16(16U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -665,9 +665,9 @@ TEST(BitSpan, SetGetU32)
     {
         auto ref = randU32();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 32U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setUxx(ref, 32U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getU32(32U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getU32(32U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -679,9 +679,9 @@ TEST(BitSpan, SetGetU64)
     {
         auto ref = randU64();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setUxx(ref, 64U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setUxx(ref, 64U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getU64(64U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getU64(64U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -693,9 +693,9 @@ TEST(BitSpan, SetGetI8)
     {
         auto ref = randI8();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 8U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setIxx(ref, 8U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getI8(8U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getI8(8U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -707,9 +707,9 @@ TEST(BitSpan, SetGetI16)
     {
         auto ref = randI16();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 16U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setIxx(ref, 16U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getI16(16U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getI16(16U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -721,9 +721,9 @@ TEST(BitSpan, SetGetI32)
     {
         auto ref = randI32();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 32U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setIxx(ref, 32U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getI32(32U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getI32(32U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }
@@ -735,9 +735,9 @@ TEST(BitSpan, SetGetI64)
     {
         auto ref = randI64();
         const auto offset = i * sizeof(ref) * 8U;
-        auto rslt = nunavut::support::bitspan(data, offset).setIxx(ref, 64U);
+        auto rslt = nunavut::support::bitspan(data, sizeof(data), offset).setIxx(ref, 64U);
         ASSERT_TRUE(rslt.has_value()) << "Error was " << rslt.error();
-        auto act = nunavut::support::const_bitspan(data, offset).getI64(64U);
+        auto act = nunavut::support::const_bitspan(data, sizeof(data), offset).getI64(64U);
         ASSERT_EQ(hex(ref), hex(act)) << i;
     }
 }

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -14,22 +14,45 @@ TEST(BitSpan, Constructor) {
     uint8_t srcVar = 0x8F;
     std::array<uint8_t,5> srcArray{ 1, 2, 3, 4, 5 };
     {
-        nunavut::support::bitspan sp{{&srcVar, 1}};
+        nunavut::support::bitspan sp{&srcVar, 1};
         ASSERT_EQ(sp.size(), 1U*8U);
+        ASSERT_EQ(sp.offset(), 0U);
+    }
+    {
+        nunavut::support::bitspan sp{&srcVar, 1, 4};
+        ASSERT_EQ(sp.size(), 4U);
+        ASSERT_EQ(sp.offset(), 4U);
     }
     {
         nunavut::support::bitspan sp{srcArray};
         ASSERT_EQ(sp.size(), 5U*8U);
+        ASSERT_EQ(sp.offset(), 0U);
+    }
+    {
+        nunavut::support::bitspan sp{srcArray, 4};
+        ASSERT_EQ(sp.size(), 4U*8U + 4U);
+        ASSERT_EQ(sp.offset(), 4U);
     }
     const uint8_t csrcVar = 0x8F;
     const std::array<const uint8_t,5> csrcArray{ 1, 2, 3, 4, 5 };
     {
-        nunavut::support::const_bitspan sp{{&csrcVar, 1}};
+        nunavut::support::const_bitspan sp{&csrcVar, 1};
         ASSERT_EQ(sp.size(), 1U*8U);
+    }
+    {
+        nunavut::support::const_bitspan sp{&csrcVar, 1, 4};
+        ASSERT_EQ(sp.size(), 4U);
+        ASSERT_EQ(sp.offset(), 4U);
     }
     {
         nunavut::support::const_bitspan sp{csrcArray};
         ASSERT_EQ(sp.size(), 5U*8U);
+        ASSERT_EQ(sp.offset(), 0U);
+    }
+    {
+        nunavut::support::const_bitspan sp{csrcArray, 4};
+        ASSERT_EQ(sp.size(), 4U*8U + 4U);
+        ASSERT_EQ(sp.offset(), 4U);
     }
 }
 
@@ -166,10 +189,10 @@ TEST(BitSpan, CopyBitsWithAlignedOffsetNonByteLen) {
     std::array<uint8_t,1> dst{};
     memset(dst.data(), 0, dst.size());
 
-    nunavut::support::const_bitspan({src}, 2U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
+    nunavut::support::const_bitspan(src, 2U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
     ASSERT_EQ(0x1U, dst[0]);
 
-    nunavut::support::const_bitspan({src}, 3U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
+    nunavut::support::const_bitspan(src, 3U * 8U).copyTo(nunavut::support::bitspan{dst}, 4);
     ASSERT_EQ(0x2U, dst[0]);
 }
 
@@ -207,7 +230,7 @@ TEST(BitSpan, SaturateBufferFragmentBitLength)
     ASSERT_EQ(31U, const_bitspan(data,  1U).saturateBufferFragmentBitLength(32));
     ASSERT_EQ(16U, const_bitspan(data,  0U).saturateBufferFragmentBitLength(16));
     ASSERT_EQ(15U, const_bitspan(data, 17U).saturateBufferFragmentBitLength(24));
-    ASSERT_EQ(0U,  const_bitspan({data.data(), 2}, 24U).saturateBufferFragmentBitLength(24));
+    ASSERT_EQ(0U,  const_bitspan(data.data(), 2, 24U).saturateBufferFragmentBitLength(24));
 }
 
 
@@ -216,7 +239,7 @@ TEST(BitSpan, GetBits)
     std::array<const uint8_t, 16> src{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
     std::array<uint8_t, 6> dst{};
     memset(dst.data(), 0xAA, dst.size());
-    nunavut::support::const_bitspan{{src.data(), 6U}, 0}.getBits(dst, 0);
+    nunavut::support::const_bitspan{src.data(), 6U}.getBits(dst, 0);
     ASSERT_EQ(0xAA, dst[0]);   // no bytes copied
     ASSERT_EQ(0xAA, dst[1]);
     ASSERT_EQ(0xAA, dst[2]);
@@ -224,7 +247,7 @@ TEST(BitSpan, GetBits)
     ASSERT_EQ(0xAA, dst[4]);
     ASSERT_EQ(0xAA, dst[5]);
 
-    nunavut::support::const_bitspan{{src.data(), 0U}, 0}.getBits(dst, 4U*8U);
+    nunavut::support::const_bitspan{src.data(), 0U}.getBits(dst, 4U*8U);
     ASSERT_EQ(0x00, dst[0]);   // all bytes zero-extended
     ASSERT_EQ(0x00, dst[1]);
     ASSERT_EQ(0x00, dst[2]);
@@ -233,7 +256,7 @@ TEST(BitSpan, GetBits)
     ASSERT_EQ(0xAA, dst[5]);
 
     memset(dst.data(), 0xAA, dst.size());
-    nunavut::support::const_bitspan{{src.data(), 6}, 6U*8U}.getBits(dst, 4U*8U);
+    nunavut::support::const_bitspan{src.data(), 6, 6U*8U}.getBits(dst, 4U*8U);
     ASSERT_EQ(0x00, dst[0]);   // all bytes zero-extended
     ASSERT_EQ(0x00, dst[1]);
     ASSERT_EQ(0x00, dst[2]);
@@ -242,7 +265,7 @@ TEST(BitSpan, GetBits)
     ASSERT_EQ(0xAA, dst[5]);
 
     memset(dst.data(), 0xAA, dst.size());
-    nunavut::support::const_bitspan{{src.data(), 6U}, 5U*8U}.getBits(dst, 4U*8U);
+    nunavut::support::const_bitspan{src.data(), 6U, 5U*8U}.getBits(dst, 4U*8U);
     ASSERT_EQ(0x66, dst[0]);   // one byte copied
     ASSERT_EQ(0x00, dst[1]);   // the rest are zero-extended
     ASSERT_EQ(0x00, dst[2]);
@@ -251,7 +274,7 @@ TEST(BitSpan, GetBits)
     ASSERT_EQ(0xAA, dst[5]);
 
     memset(dst.data(), 0xAA, dst.size());
-    nunavut::support::const_bitspan{{src.data(), 6}, 4U * 8U + 4U}.getBits(dst, 4U*8U);
+    nunavut::support::const_bitspan{src.data(), 6, 4U * 8U + 4U}.getBits(dst, 4U*8U);
     ASSERT_EQ(0x65, dst[0]);   // one-and-half bytes are copied
     ASSERT_EQ(0x06, dst[1]);   // the rest are zero-extended
     ASSERT_EQ(0x00, dst[2]);
@@ -260,7 +283,7 @@ TEST(BitSpan, GetBits)
     ASSERT_EQ(0xAA, dst[5]);
 
     memset(dst.data(), 0xAA, dst.size());
-    nunavut::support::const_bitspan{{src.data(), 7}, 4U}.getBits(dst, 4U*8U);
+    nunavut::support::const_bitspan{src.data(), 7, 4U}.getBits(dst, 4U*8U);
     ASSERT_EQ(0x21, dst[0]);   // all bytes are copied offset by half
     ASSERT_EQ(0x32, dst[1]);
     ASSERT_EQ(0x43, dst[2]);
@@ -269,7 +292,7 @@ TEST(BitSpan, GetBits)
     ASSERT_EQ(0xAA, dst[5]);
 
     memset(dst.data(), 0xAA, dst.size());
-    nunavut::support::const_bitspan{{src.data(), 7}, 4U}.getBits(dst, 3U*8U + 4U);
+    nunavut::support::const_bitspan{src.data(), 7, 4U}.getBits(dst, 3U*8U + 4U);
     ASSERT_EQ(0x21, dst[0]);   // 28 bits are copied
     ASSERT_EQ(0x32, dst[1]);
     ASSERT_EQ(0x43, dst[2]);
@@ -309,10 +332,10 @@ TEST(BitSpan, SetIxx_bufferOverflow)
 {
     uint8_t buffer[] = {0x00, 0x00, 0x00};
 
-    auto rc = nunavut::support::bitspan{{buffer, 3U}, 2U*8U}.setIxx(0xAA, 8);
+    auto rc = nunavut::support::bitspan{buffer, 3U, 2U*8U}.setIxx(0xAA, 8);
     ASSERT_TRUE(rc);
     ASSERT_EQ(0xAA, buffer[2]);
-    rc = nunavut::support::bitspan{{buffer, 2U}, 2U*8U}.setIxx(0xAA, 8);
+    rc = nunavut::support::bitspan{buffer, 2U, 2U*8U}.setIxx(0xAA, 8);
     ASSERT_FALSE(rc);
     ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, rc.error());
     ASSERT_EQ(0xAA, buffer[2]);
@@ -325,7 +348,7 @@ TEST(BitSpan, SetIxx_bufferOverflow)
 TEST(BitSpan, SetBit)
 {
     uint8_t buffer[] = {0x00};
-    nunavut::support::bitspan sp{{buffer, sizeof(buffer)}};
+    nunavut::support::bitspan sp{buffer, sizeof(buffer)};
 
     auto res = sp.setBit(true);
     ASSERT_TRUE(res);
@@ -344,7 +367,7 @@ TEST(BitSpan, SetBit_bufferOverflow)
 {
     uint8_t buffer[] = {0x00, 0x00};
 
-    auto res = nunavut::support::bitspan{{buffer, 1U}, 8}.setBit(true);
+    auto res = nunavut::support::bitspan{buffer, 1U, 8}.setBit(true);
 
     ASSERT_FALSE(res.has_value());
     ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, res.error());
@@ -354,7 +377,7 @@ TEST(BitSpan, SetBit_bufferOverflow)
 TEST(BitSpan, GetBit)
 {
     const uint8_t buffer[] = {0x01};
-    nunavut::support::const_bitspan sp{{buffer, 1U}, 0};
+    nunavut::support::const_bitspan sp{buffer, 1U, 0};
     ASSERT_EQ(true, sp.getBit());
     ASSERT_EQ(false, sp.at_offset(1).getBit());
 }
@@ -833,9 +856,10 @@ static bool helperPackUnpack(const float source_value, uint16_t compare_mask, si
     return true;
 }
 
-/**
- * Test pack/unpack stability.
- */
+
+///
+/// Test pack/unpack stability.
+///
 TEST(BitSpan, Float16PackUnpack)
 {
     const uint32_t signalling_nan_bits = 0x7F800000U | 0x200000U;
@@ -871,7 +895,7 @@ TEST(BitSpan, Set16)
     uint8_t buf[3];
     buf[2] = 0x00;
 
-    nunavut::support::bitspan{ {buf, sizeof(buf)} }.setF16(3.14f);
+    nunavut::support::bitspan{ buf, sizeof(buf) }.setF16(3.14f);
     ASSERT_EQ(0x48, buf[0]);
     ASSERT_EQ(0x42, buf[1]);
     ASSERT_EQ(0x00, buf[2]);
@@ -888,7 +912,7 @@ TEST(BitSpan, Get16)
     // >>> hex(int.from_bytes(np.array([np.float16('3.14')]).tobytes(), 'little'))
     // '0x4248'
     const uint8_t buf[3] = {0x48, 0x42, 0x00};
-    const float result = nunavut::support::const_bitspan{ { buf, sizeof(buf) } }.getF16( );
+    const float result = nunavut::support::const_bitspan{ buf }.getF16( );
     ASSERT_TRUE(CompareFloatsNear(3.14f, result, 0.001f));
 }
 
@@ -896,9 +920,9 @@ TEST(BitSpan, Get16)
 // +--------------------------------------------------------------------------+
 // | testNunavutSetF32
 // +--------------------------------------------------------------------------+
-/**
- * Compare the results of Nunavut serialization to the IEEE definition. These must match.
- */
+///
+/// Compare the results of Nunavut serialization to the IEEE definition. These must match.
+///
 static void helperAssertSerFloat32SameAsIEEE(const float original_value, const uint8_t* serialized_result)
 {
     union
@@ -924,27 +948,27 @@ static void helperAssertSerFloat32SameAsIEEE(const float original_value, const u
 TEST(BitSpan, SetF32)
 {
     uint8_t buffer[] = {0x00, 0x00, 0x00, 0x00};
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( 3.14f);
+    nunavut::support::bitspan{ buffer, sizeof(buffer) }.setF32( 3.14f);
     helperAssertSerFloat32SameAsIEEE(3.14f, buffer);
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( -3.14f);
+    nunavut::support::bitspan{ buffer }.setF32( -3.14f);
     helperAssertSerFloat32SameAsIEEE(-3.14f, buffer);
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( -NAN);
+    nunavut::support::bitspan{ buffer }.setF32( -NAN);
     helperAssertSerFloat32SameAsIEEE(-NAN, buffer);
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( NAN);
+    nunavut::support::bitspan{ buffer }.setF32( NAN);
     helperAssertSerFloat32SameAsIEEE(NAN, buffer);
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( INFINITY);
+    nunavut::support::bitspan{ buffer }.setF32( INFINITY);
     helperAssertSerFloat32SameAsIEEE(std::numeric_limits<float>::infinity(), buffer);
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF32( -INFINITY);
+    nunavut::support::bitspan{ buffer }.setF32( -INFINITY);
     helperAssertSerFloat32SameAsIEEE(-std::numeric_limits<float>::infinity(), buffer);
 }
 
@@ -957,25 +981,25 @@ TEST(BitSpan, GetF32)
     // >>> hex(int.from_bytes(np.array([-np.float32('infinity')]).tobytes(), 'little'))
     // '0xff800000'
     const uint8_t buffer_neg_inf[] = {0x00, 0x00, 0x80, 0xFF};
-    float result = nunavut::support::const_bitspan{ { buffer_neg_inf, sizeof(buffer_neg_inf) } }.getF32( );
+    float result = nunavut::support::const_bitspan{ buffer_neg_inf }.getF32( );
     ASSERT_FLOAT_EQ(-std::numeric_limits<float>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([np.float32('infinity')]).tobytes(), 'little'))
     // '0x7f800000'
     const uint8_t buffer_inf[] = {0x00, 0x00, 0x80, 0x7F};
-    result = nunavut::support::const_bitspan{ { buffer_inf, sizeof(buffer_inf) } }.getF32( );
+    result = nunavut::support::const_bitspan{ buffer_inf }.getF32( );
     ASSERT_FLOAT_EQ(std::numeric_limits<float>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([np.float32('nan')]).tobytes(), 'little'))
     // '0x7fc00000'
     const uint8_t buffer_nan[] = {0x00, 0x00, 0xC0, 0x7F};
-    result = nunavut::support::const_bitspan{ { buffer_nan, sizeof(buffer_nan) } }.getF32( );
+    result = nunavut::support::const_bitspan{ buffer_nan }.getF32( );
     ASSERT_TRUE(std::isnan(result));
 
     // >>> hex(int.from_bytes(np.array([np.float32('3.14')]).tobytes(), 'little'))
     // '0x4048f5c3'
     const uint8_t buffer_pi[] = {0xC3, 0xF5, 0x48, 0x40};
-    result = nunavut::support::const_bitspan{ { buffer_pi, sizeof(buffer_pi) } }.getF32( );
+    result = nunavut::support::const_bitspan{ buffer_pi }.getF32( );
     ASSERT_FLOAT_EQ(3.14f, result);
 }
 
@@ -989,34 +1013,34 @@ TEST(BitSpan, GetF64)
     // >>> hex(int.from_bytes(np.array([np.float64('3.141592653589793')]).tobytes(), 'little'))
     // '0x400921fb54442d18'
     const uint8_t buffer_pi[] = {0x18, 0x2D, 0x44, 0x54, 0xFB, 0x21, 0x09, 0x40};
-    double result = nunavut::support::const_bitspan{ { buffer_pi, sizeof(buffer_pi) } }.getF64( );
+    double result = nunavut::support::const_bitspan{ buffer_pi }.getF64( );
     ASSERT_DOUBLE_EQ(3.141592653589793, result);
 
     // >>> hex(int.from_bytes(np.array([np.float64('infinity')]).tobytes(), 'little'))
     // '0x7ff0000000000000'
     const uint8_t buffer_inf[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x7F};
-    result = nunavut::support::const_bitspan{ { buffer_inf, sizeof(buffer_inf) } }.getF64( );
+    result = nunavut::support::const_bitspan{ buffer_inf }.getF64( );
     ASSERT_DOUBLE_EQ(std::numeric_limits<double>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([-np.float64('infinity')]).tobytes(), 'little'))
     // '0xfff0000000000000'
     const uint8_t buffer_neg_inf[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0xFF};
-    result = nunavut::support::const_bitspan{ { buffer_neg_inf, sizeof(buffer_neg_inf) } }.getF64( );
+    result = nunavut::support::const_bitspan{ buffer_neg_inf }.getF64( );
     ASSERT_DOUBLE_EQ(-std::numeric_limits<double>::infinity(), result);
 
     // >>> hex(int.from_bytes(np.array([np.float64('nan')]).tobytes(), 'little'))
     // '0x7ff8000000000000'
     const uint8_t buffer_nan[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x7F};
-    result = nunavut::support::const_bitspan{ { buffer_nan, sizeof(buffer_nan) } }.getF64( );
+    result = nunavut::support::const_bitspan{ buffer_nan }.getF64( );
     ASSERT_TRUE(std::isnan(result));
 }
 
 // +--------------------------------------------------------------------------+
 // | testNunavutSetF64
 // +--------------------------------------------------------------------------+
-/**
- * Compare the results of Nunavut serialization to the IEEE definition. These must match.
- */
+///
+/// Compare the results of Nunavut serialization to the IEEE definition. These must match.
+///
 static bool helperAssertSerFloat64SameAsIEEE(const double original_value, const uint8_t* serialized_result)
 {
     union
@@ -1047,26 +1071,26 @@ static bool helperAssertSerFloat64SameAsIEEE(const double original_value, const 
 TEST(BitSpan, SetF64)
 {
     uint8_t buffer[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( 3.141592653589793);
+    nunavut::support::bitspan{ buffer }.setF64( 3.141592653589793);
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(3.141592653589793, buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -3.141592653589793);
+    nunavut::support::bitspan{ buffer }.setF64( -3.141592653589793);
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-3.141592653589793, buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -std::numeric_limits<double>::quiet_NaN());
+    nunavut::support::bitspan{ buffer }.setF64( -std::numeric_limits<double>::quiet_NaN());
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-std::numeric_limits<double>::quiet_NaN(), buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( std::numeric_limits<double>::quiet_NaN());
+    nunavut::support::bitspan{ buffer }.setF64( std::numeric_limits<double>::quiet_NaN());
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(std::numeric_limits<double>::quiet_NaN(), buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( std::numeric_limits<double>::infinity());
+    nunavut::support::bitspan{ buffer }.setF64( std::numeric_limits<double>::infinity());
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(std::numeric_limits<double>::infinity(), buffer));
 
     memset(buffer, 0, sizeof(buffer));
-    nunavut::support::bitspan{ { buffer, sizeof(buffer) } }.setF64( -std::numeric_limits<double>::infinity());
+    nunavut::support::bitspan{ buffer }.setF64( -std::numeric_limits<double>::infinity());
     ASSERT_TRUE(helperAssertSerFloat64SameAsIEEE(-std::numeric_limits<double>::infinity(), buffer));
 }

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -9,8 +9,55 @@
 #include "test_helpers.hpp"
 #include "uavcan/time/TimeSystem_0_1.hpp"
 #include "regulated/basics/Struct__0_1.hpp"
+#include "regulated/basics/Service_0_1.hpp"
 #include "regulated/basics/Primitive_0_1.hpp"
 
+
+static_assert(
+    not regulated::basics::Struct__0_1::IsServiceType,
+    "Regular types are not service types");
+
+static_assert(
+    regulated::basics::Service::Request_0_1::IsServiceType,
+    "Request is a service type");
+static_assert(
+    regulated::basics::Service::Response_0_1::IsServiceType,
+    "Response is a service type");
+static_assert(
+    regulated::basics::Service::Service_0_1::IsServiceType,
+    "Service is a service type");
+
+static_assert(
+    not regulated::basics::Service::Request_0_1::IsService,
+    "Request is not a service");
+static_assert(
+    not regulated::basics::Service::Response_0_1::IsService,
+    "Response is not a service");
+static_assert(
+    regulated::basics::Service::Service_0_1::IsService,
+    "Service is a service");
+
+
+static_assert(
+    regulated::basics::Service::Request_0_1::IsRequest,
+    "Request is a request");
+static_assert(
+    not regulated::basics::Service::Response_0_1::IsRequest,
+    "Response is not a request");
+static_assert(
+    not regulated::basics::Service::Service_0_1::IsRequest,
+    "Service is not a request");
+
+
+static_assert(
+    not regulated::basics::Service::Request_0_1::IsResponse,
+    "Request is not a response");
+static_assert(
+    regulated::basics::Service::Response_0_1::IsResponse,
+    "Response is a response");
+static_assert(
+    not regulated::basics::Service::Service_0_1::IsResponse,
+    "Service is not a response");
 
 
 TEST(Serialization, BasicSerialize) {

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -19,7 +19,7 @@ TEST(Serialization, BasicSerialize) {
     {
         a.value = 1;
         std::fill(std::begin(buffer), std::end(buffer), 0xAA);
-        const auto result = a.serialize({{buffer}});
+        const auto result = a.serialize(buffer);
         ASSERT_TRUE(result);
         ASSERT_EQ(1U, *result);
         ASSERT_EQ(1U, buffer[0]);
@@ -28,7 +28,7 @@ TEST(Serialization, BasicSerialize) {
     {
         a.value = 0xFF;
         std::fill(std::begin(buffer), std::end(buffer), 0xAA);
-        const auto result = a.serialize({{buffer}});
+        const auto result = a.serialize(buffer);
         ASSERT_TRUE(result);
         ASSERT_EQ(1U, *result);
         ASSERT_EQ(0x0FU, buffer[0]);
@@ -197,7 +197,7 @@ TEST(Serialization, StructReference)
     uint8_t buf[sizeof(reference)];
     (void) memset(&buf[0], 0x55U, sizeof(buf));  // fill out canaries
 
-    auto result = obj.serialize({{buf, sizeof(buf)}});
+    auto result = obj.serialize(buf);
     ASSERT_TRUE(result) << "Error is " << static_cast<int>(result.error());
 
     EXPECT_EQ(sizeof(reference) - 16U, result.value());
@@ -259,7 +259,7 @@ TEST(Serialization, StructReference)
     ASSERT_EQ(0U, obj.aligned_bitpacked_le3.size());
 
     // // Deserialize the above reference representation and compare the result against the original object.
-    result = obj.deserialize({{reference}, 0U});
+    result = obj.deserialize(reference);
     ASSERT_TRUE(result) << "Error was " << result.error();
     ASSERT_EQ(sizeof(reference) - 16U, result.value());   // 16 trailing bytes implicitly truncated away
 
@@ -296,7 +296,7 @@ TEST(Serialization, StructReference)
     // ASSERT_EQ(1, obj.aligned_bitpacked_le3.bitpacked[0]);       // unused MSB are zero-padded
 
     // Repeat the above, but apply implicit zero extension somewhere in the middle.
-    result = obj.deserialize({{reference, 25U}, 0U});
+    result = obj.deserialize({reference, 25U, 0U});
     ASSERT_TRUE(result) << "Error was " << result.error();
     ASSERT_EQ(25U, result.value());   // the returned size shall not exceed the buffer size
 
@@ -376,13 +376,13 @@ TEST(Serialization, Primitive)
 
         uint8_t buf[regulated::basics::Primitive_0_1::SERIALIZATION_BUFFER_SIZE_BYTES];
         std::memset(buf, 0, sizeof(buf));
-        auto result = ref.serialize({{buf, sizeof(buf)}});
+        auto result = ref.serialize(buf);
         ASSERT_TRUE(result) << "Error is " << result.error();
         ASSERT_EQ(
             static_cast<size_t>(regulated::basics::Primitive_0_1::SERIALIZATION_BUFFER_SIZE_BYTES), result.value());
 
         regulated::basics::Primitive_0_1 obj;
-        result = obj.deserialize({ {buf, sizeof(buf)} });
+        result = obj.deserialize(buf);
         ASSERT_TRUE(result);
         EXPECT_EQ(
             static_cast<size_t>(regulated::basics::Primitive_0_1::SERIALIZATION_BUFFER_SIZE_BYTES), result.value());
@@ -452,7 +452,7 @@ TEST(Serialization, CCppBackAndForth)
         std::memset(buf, 0, sizeof(buf));
 
         // We serialize structure from C++
-        auto result = cpp_part.serialize({{buf, sizeof(buf)}, 0});
+        auto result = cpp_part.serialize(buf);
         ASSERT_TRUE(result) << "Error is " << result.error();
         ASSERT_EQ(
             static_cast<size_t>(regulated::zubax::actuator::esc::Status_0_1::SERIALIZATION_BUFFER_SIZE_BYTES), result.value());
@@ -494,7 +494,7 @@ TEST(Serialization, CCppBackAndForth)
 
         // And deserialize again in C++
         regulated::zubax::actuator::esc::Status_0_1 cpp_parsed;
-        result = cpp_parsed.deserialize({ {buf, sizeof(buf)} });
+        result = cpp_parsed.deserialize(buf);
         ASSERT_TRUE(result);
         EXPECT_EQ(
             static_cast<size_t>(regulated::zubax::actuator::esc::Status_0_1::SERIALIZATION_BUFFER_SIZE_BYTES),


### PR DESCRIPTION
This patch includes some quality-of-life improvements:
1. All external methods in serialization support header-only library are now marked with `inline` to avoid linker errors if serialization code was included from several different translation units.
2. Refactor `bitspan` constructors to make user code easier and should fix #254.
```cpp
uavcan::node::Heartbeat_1_0 hb{};
std::array<uint8_t, uavcan::node::Heartbeat_1_0::SERIALIZATION_BUFFER_SIZE_BYTES> data;

// before change:
hb.serialize({{data}, 0});

// after change:
hb.serialize(data);
```
3. Change naming of service types from `uavcan::node::GetInfo_1_0::Request_1_0` to `uavcan::node::GetInfo::Request_1_0`
4. Add a special service type alongside `Request` and `Response` and some constexpr boolean traits to ease templating on services:
```cpp
namespace uavcan
{
namespace node
{
namespace GetInfo
{
struct Request_1_0 final
{
    // ...
    static constexpr bool IsServiceType = true;
    static constexpr bool IsService = false;
    static constexpr bool IsRequest = true;
    static constexpr bool IsResponse = false;
    // ...
};

struct Response_1_0 final
{
    // ...
    static constexpr bool IsServiceType = true;
    static constexpr bool IsService = false;
    static constexpr bool IsRequest = false;
    static constexpr bool IsResponse = true;
    // ...
};

struct Service_1_0 {
    static constexpr bool IsServiceType = true;
    static constexpr bool IsService = true;
    static constexpr bool IsRequest = false;
    static constexpr bool IsResponse = false;

    using Request = Request_1_0;
    using Response = Response_1_0;
};

} // namespace GetInfo_1_0
} // namespace node
} // namespace uavcan
```