### PR TITLE
Require PyDSDL v1.16 at least to ensure support for *.dsdl file extension

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ package_dir=
     =src
 packages=find:
 install_requires=
-    pydsdl ~= 1.15
+    pydsdl ~= 1.16
     pyyaml
     importlib-resources
 

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -7,7 +7,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "1.8.2"  #: The version number used in the release of nunavut to pypi.
+__version__ = "1.8.3"  #: The version number used in the release of nunavut to pypi.
 
 
 __license__ = "MIT"

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     autopep8
     rope
     isort
-    rstcheck
+    rstcheck[sphinx] >= 6.0.0
 
 # +---------------------------------------------------------------------------+
 # | CONFIGURATION
@@ -198,10 +198,10 @@ commands =
 [testenv:lint]
 basepython = python3.9
 deps =
+     {[dev]deps}
     black
     flake8
     doc8
-    rstcheck
     Pygments
     mypy
     lxml
@@ -213,7 +213,13 @@ commands =
     flake8 --benchmark --tee --output-file={envtmpdir}/flake8.txt --filename=*.py --exclude=**/jinja2/*,**/markupsafe/* src
     black --check --line-length 120 --force-exclude '(/jinja2/|/markupsafe\/)' src
     doc8 {toxinidir}/docs
-    rstcheck --ignore-directives D001 --ignore-directives autofunction,automodule,argparse --ignore-roles mod,func,class -r {toxinidir}
+    rstcheck --ignore-directives D001 \
+             --ignore-directives autofunction,automodule,argparse \
+             -r \
+             {toxinidir}/docs \
+             {toxinidir}/CONTRIBUTING.rst \
+             {toxinidir}/README.rst \
+             {toxinidir}/LICENSE.rst
     mypy -m nunavut \
          -m nunavut.jinja \
          -p nunavut.lang \


### PR DESCRIPTION
https://github.com/OpenCyphal/pydsdl/releases/tag/1.16.0
