### PR TITLE
First iteration on v2

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -164,6 +164,25 @@ jobs:
                           --endianness ${{ matrix.endianness }} \
                           ${{ matrix.flag }}
 
+  language-verification-cpp-11:
+    runs-on: ubuntu-latest
+    needs: test
+    container: uavcan/c_cpp:ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: verify
+      run: |
+        .github/verify.py --override .github/verify_global.ini \
+                          --build-type Debug \
+                          --language-standard c++11 \
+                          --language cpp \
+                          --platform native32 \
+                          --toolchain-family gcc \
+                          --endianness any \
+                          --none
+
   language-verification-cpp-14:
     runs-on: ubuntu-latest
     needs: test

--- a/conftest.py
+++ b/conftest.py
@@ -31,48 +31,6 @@ from sybil.parsers.doctest import DocTestParser
 from nunavut import Namespace
 
 
-class NamedTempFileWindowsSafe:
-    """
-    Replacement for Python's NamedTemporaryFile which doesn't really work properly on Windows.
-    """
-
-    def __init__(
-        self,
-        mode: str = "r",
-        encoding: str = "utf-8",
-        suffix: typing.Optional[str] = None,
-        newline: typing.Optional[str] = None,
-    ):
-        self._mode = mode
-        self._encoding = encoding
-        self._suffix = suffix
-        self._newline = newline
-        self._tempfile: typing.Optional[typing.IO] = None
-
-    def _generate_temporary_filename(self) -> str:
-        return os.urandom(32).hex()
-
-    def _new_temporary_filename(self) -> pathlib.Path:
-        filename = pathlib.Path(tempfile.gettempdir(), self._generate_temporary_filename())
-        if self._suffix is not None:
-            filename = filename.with_suffix(self._suffix)
-        if filename.exists():
-            raise RuntimeError("Temporary file {} already exists!?".format(str(filename)))
-        return filename
-
-    def __enter__(self) -> typing.IO:
-        filename = self._new_temporary_filename()
-        filename.touch()
-        self._tempfile = filename.open(mode=self._mode, encoding=self._encoding, newline=self._newline)
-        return self._tempfile
-
-    def __exit__(self, exc_type: typing.Any, exc_val: typing.Any, exc_tb: typing.Any) -> None:
-        if self._tempfile is not None:
-            self._tempfile.close()
-            os.remove(self._tempfile.name)
-            self._tempfile = None
-
-
 # +-------------------------------------------------------------------------------------------------------------------+
 # | PYTEST HOOKS
 # +-------------------------------------------------------------------------------------------------------------------+
@@ -119,6 +77,10 @@ def pytest_addoption(parser):  # type: ignore
 
 @pytest.fixture
 def run_nnvg(request):  # type: ignore
+    """
+    Test helper for invoking the nnvg commandline script as part of a unit test.
+    """
+
     def _run_nnvg(
         gen_paths: typing.Any,
         args: typing.List[str],
@@ -233,6 +195,10 @@ class GenTestPaths:
 
 @pytest.fixture(scope="function")
 def gen_paths(request):  # type: ignore
+    """
+    Used by the "gentest" unittests in Nunavut to standardize output paths for generated code created as part of
+    the tests. Use the --keep-generated argument to disable the auto-clean behaviour this fixture provides by default.
+    """
     g = GenTestPaths(str(request.fspath), request.config.option.keep_generated, request.node.name)
     request.addfinalizer(g.test_path_finalizer)
     return g
@@ -276,10 +242,10 @@ def assert_language_config_value(request):  # type: ignore
     """
     Assert that a given configuration value is set for the target language.
     """
-    from nunavut.lang import LanguageContext
+    from nunavut.lang import LanguageContext, LanguageContextBuilder
 
     def _assert_language_config_value(
-        target_language: typing.Union[typing.Optional[str], LanguageContext],
+        target_language: typing.Union[str, LanguageContext],
         key: str,
         expected_value: typing.Any,
         message: typing.Optional[str],
@@ -287,7 +253,11 @@ def assert_language_config_value(request):  # type: ignore
         if isinstance(target_language, LanguageContext):
             lctx = target_language
         else:
-            lctx = LanguageContext(target_language)
+            lctx = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language(target_language)
+                .create()
+            )
 
         language = lctx.get_target_language()
         if language is None:
@@ -296,48 +266,6 @@ def assert_language_config_value(request):  # type: ignore
             raise AssertionError(message)
 
     return _assert_language_config_value
-
-
-@pytest.fixture
-def configurable_language_context_factory(request):  # type: ignore
-    """
-    Use to create a LanguageContext that the test can write configuration overrides for.
-
-    Example:
-
-        .. code-block:: python
-
-            def test_my_test(configurable_language_context_factory):
-                lctx = configurable_language_context_factory({'nunavut.lang.c': {'foo': 'bar'}},
-                                                             'c')
-                assert lctx.get_target_language().get_config_value('foo') == 'bar'
-
-        .. invisible-code-block: python
-
-            test_my_test(configurable_language_context_factory)
-
-    """
-    from nunavut.lang import LanguageContext
-
-    def _make_configurable_language_context(
-        config_overrides: typing.Mapping[str, typing.Mapping[str, typing.Any]],
-        target_language: typing.Optional[str] = None,
-        extension: typing.Optional[str] = None,
-        namespace_output_stem: typing.Optional[str] = None,
-        omit_serialization_support_for_target: bool = True,
-    ) -> LanguageContext:
-
-        from yaml import Dumper as YamlDumper
-        from yaml import dump as yaml_dump
-
-        with NamedTempFileWindowsSafe(mode="w", encoding="utf-8", suffix=".yaml", newline="\n") as config_override_file:
-            yaml_dump(config_overrides, config_override_file, Dumper=YamlDumper)
-            config_override_file.flush()
-            return LanguageContext(
-                target_language, extension, additional_config_files=[pathlib.Path(config_override_file.name)]
-            )
-
-    return _make_configurable_language_context
 
 
 @pytest.fixture
@@ -370,18 +298,25 @@ def jinja_filter_tester(request):  # type: ignore
     You can also control the language context:
 
         .. code-block: python
-            lctx = configurable_language_context_factory({'nunavut.lang.c': {'enable_stropping': False}}, 'c')
+
+            from nunavut.lang import LanguageContextBuilder, Language
+            lctx = (
+                LanguageContextBuilder()
+                    .set_target_language("c")
+                    .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, False)
+                    .create()
+            )
 
             jinja_filter_tester(filter_dummy, template, rendered, lctx, I=I)
     """
     from nunavut.jinja.jinja2 import DictLoader
-    from nunavut.lang import LanguageContext
+    from nunavut.lang import LanguageContext, LanguageContextBuilder
 
     def _make_filter_test_template(
         filter_or_list_of_filters: typing.Union[None, typing.Callable, typing.List[typing.Callable]],
         body: str,
         expected: str,
-        target_language_or_language_context: typing.Union[typing.Optional[str], LanguageContext],
+        target_language_or_language_context: typing.Union[str, LanguageContext],
         **globals: typing.Optional[typing.Dict[str, typing.Any]]
     ) -> str:
         from nunavut.jinja import CodeGenEnvironment
@@ -389,7 +324,11 @@ def jinja_filter_tester(request):  # type: ignore
         if isinstance(target_language_or_language_context, LanguageContext):
             lctx = target_language_or_language_context
         else:
-            lctx = LanguageContext(target_language_or_language_context)
+            lctx = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language(target_language_or_language_context)
+                .create()
+            )
 
         if filter_or_list_of_filters is None:
             additional_filters = dict()  # type: typing.Optional[typing.Dict[str, typing.Callable]]
@@ -407,6 +346,9 @@ def jinja_filter_tester(request):  # type: ignore
             additional_filters=additional_filters,
             additional_globals=globals,
         )
+        e.update_nunavut_globals(
+            *lctx.get_target_language().get_support_module(), is_dryrun=True, omit_serialization_support=True
+        )
 
         rendered = str(e.get_template("test").render())
         if expected != rendered:
@@ -417,6 +359,21 @@ def jinja_filter_tester(request):  # type: ignore
         return rendered
 
     return _make_filter_test_template
+
+
+@pytest.fixture
+def mock_environment(request):  # type: ignore
+    """
+    A MagicMock that can be used where a jinja environment is needed.
+    """
+    from unittest.mock import MagicMock
+
+    mock_environment = MagicMock()
+    support_mock = MagicMock()
+    mock_environment.globals = {"nunavut": support_mock}
+    support_mock.support = {"omit": True}
+
+    return mock_environment
 
 
 # +-------------------------------------------------------------------------------------------------------------------+
@@ -445,7 +402,6 @@ _sy = Sybil(
         "jinja_filter_tester",
         "gen_paths",
         "assert_language_config_value",
-        "configurable_language_context_factory",
     ],
 )
 

--- a/src/nunavut/cli/__init__.py
+++ b/src/nunavut/cli/__init__.py
@@ -52,11 +52,6 @@ class _NunavutArgumentParser(argparse.ArgumentParser):
         """
         Applies rules between different arguments and handles other special cases.
         """
-        if args.list_inputs is not None and args.target_language is None and args.output_extension is None:
-            # This is a special case where we know we'll never actually use the output extension since
-            # we are only listing the input files. All other cases require either an output extension or
-            # a valid target language.
-            setattr(args, "output_extension", ".tmp")
 
         if args.omit_serialization_support and args.generate_support == "always":
             self.error(
@@ -135,8 +130,7 @@ def _make_parser() -> argparse.ArgumentParser:
         Paths to a directory containing templates to use when generating code.
 
         Templates found under these paths will override the built-in templates for a
-        given language. If no target language was provided and no template paths were
-        provided then no source will be generated.
+        given language.
 
     """
         ).lstrip(),
@@ -181,12 +175,10 @@ def _make_parser() -> argparse.ArgumentParser:
         ).lstrip(),
     )
 
-    ext_required = "--list-inputs" not in sys.argv and "--target-language" not in sys.argv and "-l" not in sys.argv
     parser.add_argument(
         "--output-extension",
         "-e",
         type=extension_type,
-        required=ext_required,
         help="The extension to use for generated files.",
     )
 
@@ -421,7 +413,7 @@ def _make_parser() -> argparse.ArgumentParser:
         description=textwrap.dedent(
             """
 
-        Options passed through to templates as `language_options` on the target language.
+        Options passed through to templates as `options` on the target language.
 
         Note that these arguments are passed though without validation, have no effect on the Nunavut
         library, and may or may not be appropriate based on the target language and generator templates
@@ -500,6 +492,35 @@ def _make_parser() -> argparse.ArgumentParser:
         code for the the c99 standard then for c11. For available support in Nunavut see the
         documentation for built-in templates
         (https://nunavut.readthedocs.io/en/latest/docs/templates.html#built-in-template-guide).
+
+    """
+        ).lstrip(),
+    )
+
+    ln_opt_group.add_argument(
+        "--configuration",
+        "-c",
+        nargs="*",
+        type=pathlib.Path,
+        help=textwrap.dedent(
+            """
+
+        There is a set of built-in configuration for Nunvut that provides default falues for known
+        languages as documented `in the template guide
+        <https://nunavut.readthedocs.io/en/latest/docs/templates.html#language-options>`_. This argument lets you
+        specify override configuration yamls.
+    """
+        ).lstrip(),
+    )
+
+    ln_opt_group.add_argument(
+        "--list-configuration",
+        "-lc",
+        action="store_true",
+        help=textwrap.dedent(
+            """
+
+        Lists all configuration values resolved for the given arguments.
 
     """
         ).lstrip(),

--- a/src/nunavut/generators.py
+++ b/src/nunavut/generators.py
@@ -42,7 +42,7 @@ class AbstractGenerator(metaclass=abc.ABCMeta):
             self._generate_namespace_types = False
         else:
             target_language = self._namespace.get_language_context().get_target_language()
-            if target_language is not None and target_language.has_standard_namespace_files:
+            if target_language.has_standard_namespace_files:
                 self._generate_namespace_types = True
             else:
                 self._generate_namespace_types = False
@@ -64,15 +64,18 @@ class AbstractGenerator(metaclass=abc.ABCMeta):
         return self._generate_namespace_types
 
     @abc.abstractmethod
-    def get_templates(self) -> typing.Iterable[pathlib.Path]:
+    def get_templates(self, omit_serialization_support: bool = False) -> typing.Iterable[pathlib.Path]:
         """
         Enumerate all templates found in the templates path.
+        :param bool omit_serialization_support: If True then templates needed only for serialization will be omitted.
         :return: A list of paths to all templates found by this Generator object.
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def generate_all(self, is_dryrun: bool = False, allow_overwrite: bool = True) -> typing.Iterable[pathlib.Path]:
+    def generate_all(
+        self, is_dryrun: bool = False, allow_overwrite: bool = True, omit_serialization_support: bool = False
+    ) -> typing.Iterable[pathlib.Path]:
         """
         Generates all output for a given :class:`nunavut.Namespace` and using
         the templates found by this object.
@@ -82,6 +85,8 @@ class AbstractGenerator(metaclass=abc.ABCMeta):
         :param bool allow_overwrite: If True then the generator will attempt to overwrite any existing files
                                 it encounters. If False then the generator will raise an error if the
                                 output file exists and the generation is not a dry-run.
+        :param bool omit_serialization_support: If True then the generator will emit only types without additional
+                                serialization and deserialization support and logic.
         :return: 0 for success. Non-zero for errors.
         :raises: PermissionError if :attr:`allow_overwrite` is False and the file exists.
         """

--- a/src/nunavut/jinja/extensions.py
+++ b/src/nunavut/jinja/extensions.py
@@ -115,11 +115,11 @@ class UseQuery(Extension):
             from nunavut.jinja import CodeGenEnvironment
             from nunavut.jinja.jinja2 import DictLoader
             from nunavut.jinja.extensions import UseQuery
-            from nunavut.lang import LanguageLoader
+            from nunavut.lang import LanguageClassLoader
             from nunavut.jinja.jinja2 import UndefinedError
             from unittest.mock import MagicMock
 
-            ln_c = LanguageLoader().load_language('c', True)
+            ln_c = LanguageClassLoader().new_language('c')
 
             lctx = MagicMock()
             lctx.get_supported_languages = MagicMock(return_value = {'c': ln_c})

--- a/src/nunavut/jinja/loaders.py
+++ b/src/nunavut/jinja/loaders.py
@@ -12,6 +12,7 @@ import typing
 import pydsdl
 
 from ..lang._config import VersionReader
+from .._utilities import ResourceSearchPolicy
 from .jinja2 import BaseLoader, Environment, FileSystemLoader, PackageLoader, TemplateNotFound
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,9 @@ class DSDLTemplateLoader(BaseLoader):
         then no :class:`nunavut.jinja.jinja2.PackageLoader` is created.
     :param str builtin_template_path: The name of the package under the ``package_name_for_templates`` package to load
         templates from. This is ignored if ``package_name_for_templates`` is None.
+    :param search_policy: If set to "FIND_ALL" then this loader will search using all loaders and will enumerate
+                          templates from all loaders. If set to "FIND_FIRST" then the loader will only use the first
+                          loader configure for both search and enumeration.
     :param Any kwargs: Arguments forwarded to the :class:`jinja.jinja2.BaseLoader`.
     """
 
@@ -51,11 +55,11 @@ class DSDLTemplateLoader(BaseLoader):
         followlinks: bool = False,
         package_name_for_templates: typing.Optional[str] = None,
         builtin_template_path: str = DEFAULT_TEMPLATE_PATH,
+        search_policy: ResourceSearchPolicy = ResourceSearchPolicy.FIND_ALL,
         **kwargs: typing.Any
     ):
         super().__init__(**kwargs)
         self._type_to_template_lookup_cache = dict()  # type: typing.Dict[pydsdl.Any, pathlib.Path]
-        self._templates_package_name = None  # type: typing.Optional[str]
 
         if templates_dirs is not None:
             for templates_dir_item in templates_dirs:
@@ -66,12 +70,15 @@ class DSDLTemplateLoader(BaseLoader):
         else:
             self._fsloader = None
 
-        if package_name_for_templates is not None:
+        if package_name_for_templates is not None and (
+            search_policy == ResourceSearchPolicy.FIND_ALL or self._fsloader is None
+        ):
             logger.info("Loading templates from package {}.{}".format(builtin_template_path, builtin_template_path))
             self._package_loader = PackageLoader(package_name_for_templates, package_path=builtin_template_path)
             self._templates_package_name = "{}.{}".format(package_name_for_templates, builtin_template_path)
         else:
             self._package_loader = None
+            self._templates_package_name = ""
 
     def get_source(
         self, environment: Environment, template: str
@@ -152,6 +159,7 @@ class DSDLTemplateLoader(BaseLoader):
             for template in templates:
                 if template.stem == 'StructureType':
                     structure_type = template
+                assert template.suffix == TEMPLATE_SUFFIX
 
             assert structure_type is not None
             assert structure_type.suffix == TEMPLATE_SUFFIX
@@ -163,7 +171,7 @@ class DSDLTemplateLoader(BaseLoader):
             for template_dir in self._fsloader.searchpath:
                 for template in pathlib.Path(template_dir).glob("**/*{}".format(TEMPLATE_SUFFIX)):
                     files.add(template)
-        if self._package_loader is not None and self._templates_package_name is not None:
+        if self._package_loader is not None:
             templates_module = importlib.import_module(self._templates_package_name)
             spec_perhaps = templates_module.__spec__
             file_perhaps = None  # type: typing.Optional[str]
@@ -172,7 +180,7 @@ class DSDLTemplateLoader(BaseLoader):
             if file_perhaps is None or file_perhaps == "builtin":
                 raise RuntimeError("Unknown template package origin?")
             templates_base_path = pathlib.Path(file_perhaps).parent
-            for t in self._package_loader.list_templates():
+            for t in self._filter_template_list_by_suffix(self._package_loader.list_templates()):
                 files.add(templates_base_path / pathlib.Path(t))
         return sorted(files)
 

--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -8,729 +8,429 @@
 This package contains modules that provide specific support for generating
 source for various languages using templates.
 """
-import abc
 import functools
-import importlib
 import logging
 import pathlib
-import types
 import typing
 
-import pydsdl
-
-from .._utilities import ResourceType, YesNoDefault, iter_package_resources, empty_list_support_files
-from ..dependencies import Dependencies, DependencyBuilder
-from ._config import LanguageConfig, VersionReader
+from ._common import IncludeGenerator as IncludeGenerator  # noqa: F401
+from ._config import LanguageConfig as LanguageConfig
+from ._language import Language as Language
+from ._language import LanguageClassLoader as LanguageClassLoader
 
 logger = logging.getLogger(__name__)
 
 
-class LanguageLoader:
+class UnsupportedLanguageError(ValueError):
     """
-    Factory class that loads language meta-data and concrete :class:`nunavut.lang.Language` objects.
-
-    :param additional_config_files: A list of paths to additional configuration files to load as configuration.
-        These will override any values found in the :file:`nunavut.lang.properties.yaml` file and files
-        appearing later in this list will override value found in earlier entries.
-
-        .. invisible-code-block: python
-
-            from nunavut.lang import LanguageLoader
-
-            subject = LanguageLoader()
-
-            c_reserved_identifiers = subject.config.get_config_value('nunavut.lang.c','reserved_identifiers')
-            assert len(c_reserved_identifiers) > 0
+    Error type raised if an unsupported language type is used.
     """
 
-    @classmethod
-    def load_language_module(cls, language_name: str) -> "types.ModuleType":
-        module_name = "nunavut.lang.{}".format(language_name)
-        return importlib.import_module(module_name)
-
-    @classmethod
-    def _load_config(cls, *additional_config_files: pathlib.Path) -> LanguageConfig:
-        parser = LanguageConfig()
-        for resource in iter_package_resources(__name__, ".yaml"):
-            ini_string = resource.read_text()
-            parser.read_string(ini_string)
-        for additional_path in additional_config_files:
-            with open(str(additional_path), "r") as additional_file:
-                parser.read_file(additional_file)
-        return parser
-
-    def __init__(self, *additional_config_files: pathlib.Path):
-        self._config = None  # type: typing.Optional[LanguageConfig]
-        self._additional_config_files = additional_config_files
-
-    @property
-    def config(self) -> LanguageConfig:
-        """
-        Meta-data about all languages merged from the Nunavut internal defaults and any additional
-        configuration files provided to this class's constructor.
-        """
-        if self._config is None:
-            self._config = self._load_config(*self._additional_config_files)
-        return self._config
-
-    def load_language(
-        self,
-        language_name: str,
-        omit_serialization_support: bool,
-        language_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
-    ) -> "Language":
-        """
-        :param str language_name:                The name of the language used by the :mod:`nunavut.lang` module.
-        :param LanguageConfig config:            The parser to load language properties into.
-        :param bool omit_serialization_support:  The value to set for the :func:`omit_serialization_support` property
-                                                for this language.
-        :param typing.Optional[typing.Mapping[str, typing.Any]] language_options: Opaque arguments passed through to the
-                    target :class:`nunavut.lang.Language` object.
-
-        :return: A new object that extends :class:`nunavut.lang.Language`.
-        :rtype: nunavut.lang.Language
-
-        .. invisible-code-block: python
-
-            from nunavut.lang import LanguageLoader
-
-        .. code-block:: python
-
-            lang_c = LanguageLoader().load_language('c', True)
-            assert lang_c.name == 'c'
-
-        .. invisible-code-block: python
-
-            # let's go ahead and load the rest of our known, internally supported languages just to raise
-            # test failures right here at the wellspring.
-
-            lang_cpp = LanguageLoader().load_language('py', True)
-            assert lang_cpp.name == 'py'
-
-            lang_js = LanguageLoader().load_language('js', True)
-            assert lang_js.name == 'js'
-
-        """
-        ln_module = self.load_language_module(language_name)
-
-        try:
-            language_type = typing.cast(typing.Type["Language"], getattr(ln_module, "Language"))
-        except AttributeError:
-            logging.debug(
-                "Unable to find a Language object in nunavut.lang.{}. Using a Generic language object".format(
-                    language_name
-                )
-            )
-            language_type = _GenericLanguage
-
-        if language_type == Language:
-            # the language module just imported the base class so let's go ahead and use _GenericLanguage
-            language_type = _GenericLanguage
-
-        return language_type(ln_module, self.config, omit_serialization_support, language_options)
+    pass
 
 
-class Language(metaclass=abc.ABCMeta):
+class LanguageContextBuilder:
     """
-    Facilities for generating source code for a specific language. Concrete Language classes must be implemented
-    by the language support package below lang and should be instantiated using
-    :class:`nunavut.lang.LanguageLoader`.
+    Used to instatiate new :class:`LanguageContext` objects.
 
-    :param str language_name:                The name of the language used by the :mod:`nunavut.lang` module.
-    :param LanguageConfig config:            The parser to load language properties into.
-    :param bool omit_serialization_support:  The value to set for the :func:`omit_serialization_support` property
-                                             for this language.
-    :param typing.Optional[typing.Mapping[str, typing.Any]] language_options: Opaque arguments passed through to the
-                target :class:`nunavut.lang.Language` object.
+    The simplest invocation will always work by using the :data:`LanguageContextBuilder.DEFAULT_TARGET_LANGUAGE`
+    constant:
 
-        .. invisible-code-block: python
+    .. code-block:: python
 
-            from nunavut.lang import Language, _GenericLanguage
-            from unittest.mock import MagicMock
+        from nunavut.lang import LanguageContextBuilder
 
-            mock_config = MagicMock()
-            mock_module = MagicMock()
+        default_language_context = LanguageContextBuilder().create()
 
-            mock_module.__name__ = 'foo'
-            try:
-                my_lang = _GenericLanguage(mock_module, mock_config, True)
-                # module must be within 'nunavut'
-                assert False
-            except RuntimeError:
-                pass
+        assert LanguageContextBuilder.DEFAULT_TARGET_LANGUAGE == default_language_context.get_target_language().name
 
-            mock_module.__name__ = 'nunavut.foo'
-            try:
-                my_lang = _GenericLanguage(mock_module, mock_config, True)
-                # module must be within 'nunavut.lang'
-                assert False
-            except RuntimeError:
-                pass
+    Typically a target language is specified at minimum. Also see constants on :class:`nunavut.lang.Language` for
+    well-known options that the builder can override:
 
-            mock_module.__name__ = 'not.nunavut.foo'
-            try:
-                my_lang = _GenericLanguage(mock_module, mock_config, True)
-                # module must be within 'nunavut.lang'
-                assert False
-            except RuntimeError:
-                pass
+    .. code-block:: python
 
-            mock_module.__name__ = 'nunavut.lang.foo'
-            my_lang = _GenericLanguage(mock_module, mock_config, True)
-            assert my_lang.name == 'foo'
+        from nunavut.lang import LanguageContextBuilder
+
+        customized_language_context = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".h")
+                .create()
+        )
+
+        assert customized_language_context.get_target_language().extension == ".h"
+
+    :param include_experimental_languages: If set then languages that are not fully supported will be allowed otherwise
+        any experimental languages will be missing and errors will be raised as if the language specified was unknown.
+
     """
 
-    @classmethod
-    def default_filter_id_for_target(cls, instance: typing.Any) -> str:
-        """
-        The default transformation of any object into a string.
-
-        :param any instance:        Any object or data that either has a name property or can be converted to a string.
-        :return: Either ``str(instance.name)`` if the instance has a name property or just ``str(instance)``
-        """
-        if hasattr(instance, "name"):
-            return str(instance.name)
-        else:
-            return str(instance)
-
-    def __init__(
-        self,
-        language_module: "types.ModuleType",
-        config: LanguageConfig,
-        omit_serialization_support: bool,
-        language_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
-    ):
-        self._globals = None  # type: typing.Optional[typing.Mapping[str, typing.Any]]
-        self._section = language_module.__name__
-        name_parts = self._section.split(".")
-        if len(name_parts) != 3 or name_parts[0] != "nunavut" or name_parts[1] != "lang":
-            raise RuntimeError("unknown module provided to Language class.")
-        self._language_name = name_parts[2]
-        self._config = config
-        self._omit_serialization_support = omit_serialization_support
-        self._language_options = config.get_config_value_as_dict(self._section, "options", dict())
-
-        if language_options is not None:
-            self._language_options.update(language_options)
-
-        self._filters = dict()  # type: typing.Dict[str, typing.Callable]
-        self._tests = dict()  # type: typing.Dict[str, typing.Callable]
-        self._uses = dict()  # type: typing.Dict[str, typing.Callable]
-
-    def __getattr__(self, name: str) -> typing.Any:
-        """
-        Any attribute access to a Language object will return the regular properties and
-        any globals defined for the language. Because of this do not extend properties
-        on this object in a way that will clash with the globals it defines (e.g. typename_
-        or valuetoken_ should not be used as the start of attribute names).
-        """
-        try:
-            return self.get_globals()[name]
-        except KeyError as e:
-            raise AttributeError(e)
-
-    def get_support_module(self) -> typing.Tuple[str, typing.Tuple[int, int, int], typing.Optional["types.ModuleType"]]:
-        """
-        Returns the module object for the language support files.
-        :return: A tuple of module name, x.y.z module version, and the module object itself.
-
-        .. invisible-code-block: python
-
-            from nunavut.lang import Language, _GenericLanguage
-            from unittest.mock import MagicMock
-
-            mock_config = MagicMock()
-            mock_module = MagicMock()
-            mock_module.__name__ = 'nunavut.lang.cpp'
-
-            my_lang = _GenericLanguage(mock_module, mock_config, True)
-            my_lang._section = "nunavut.lang.cpp"
-            module_name, support_version, _ = my_lang.get_support_module()
-
-            assert module_name == "nunavut.lang.cpp.support"
-            assert support_version[0] == 1
-
-        """
-        module_name = "{}.support".format(self._section)
-
-        try:
-            module = importlib.import_module(module_name)
-            version_tuple = VersionReader.read_version(module)
-            return (module_name, version_tuple, module)
-        except (ImportError, ValueError):
-            # No serialization support for this language
-            logger.info("No serialization support for selected target. Cannot retrieve module.")
-
-            return (module_name, (0, 0, 0), None)
-
-    @functools.lru_cache()
-    def get_dependency_builder(self, for_type: pydsdl.Any) -> DependencyBuilder:
-        return DependencyBuilder(for_type)
-
-    @abc.abstractmethod
-    def get_includes(self, dep_types: Dependencies) -> typing.List[str]:
-        """
-        Get a list of include paths that are specific to this language and the options set for it.
-        :param Dependencies dep_types: A description of the dependencies includes are needed for.
-        :return: A list of include file paths. The list may be empty if no includes were needed.
-        """
-        pass
-
-    def filter_id(self, instance: typing.Any, id_type: str = "any") -> str:
-        """
-        Produces a valid identifier in the language for a given object. The encoding may not be reversible.
-
-        :param any instance:        Any object or data that either has a name property or can be converted
-                                    to a string.
-        :param str id_type:         A type of identifier. This is different for each language. For example, for C this
-                                    value can be 'typedef', 'macro', 'function', or 'enum'.
-                                    Use 'any' to apply stropping rules for all identifier types to the instance.
-        :return: A token that is a valid identifier in the language, is not a reserved keyword, and is transformed
-                in a deterministic manner based on the provided instance.
-        """
-        return self.default_filter_id_for_target(instance)
-
-    def filter_short_reference_name(
-        self, t: pydsdl.CompositeType, stropping: YesNoDefault = YesNoDefault.DEFAULT, id_type: str = "any"
-    ) -> str:
-        """
-        Provides a string that is a shorted version of the full reference name omitting any namespace parts of the type.
-
-        :param pydsdl.CompositeType t: The DSDL type to get the reference name for.
-        :param YesNoDefault stropping: If DEFAULT then the stropping value configured for the target language is used
-                                       else this overrides that value.
-        :param str id_type:         A type of identifier. This is different for each language. For example, for C this
-                                    value can be 'typedef', 'macro', 'function', or 'enum'.
-                                    Use 'any' to apply stropping rules for all identifier types to the instance.
-        """
-        short_name = "{short}_{major}_{minor}".format(short=t.short_name, major=t.version.major, minor=t.version.minor)
-        if YesNoDefault.test_truth(stropping, self.enable_stropping):
-            return self.filter_id(short_name, id_type)
-        else:
-            return short_name
-
-    def get_config_value(self, key: str, default_value: typing.Optional[str] = None) -> str:
-        """
-        Get an optional language property from the language configuration.
-
-        :param str key: The config value to retrieve.
-        :param default_value: The value to return if the key was not in the configuration. If provided
-                this method will not raise.
-        :type default_value: typing.Optional[str]
-        :return: Either the value from the config or the default_value if provided.
-        :rtype: str
-        :raises: KeyError if the section or the key in the section does not exist and a default_value was not provided.
-        """
-        return self._config.get_config_value(self._section, key, default_value)
-
-    def get_config_value_as_bool(self, key: str, default_value: bool = False) -> bool:
-        """
-        Get an optional language property from the language configuration returning a boolean.
-
-        :param str key: The config value to retrieve.
-        :param bool default_value: The value to use if no value existed.
-        :return: The config value as either True or False.
-        :rtype: bool
-        """
-        return self._config.get_config_value_as_bool(self._section, key, default_value)
-
-    def get_config_value_as_dict(
-        self, key: str, default_value: typing.Optional[typing.Dict] = None
-    ) -> typing.Dict[str, typing.Any]:
-        """
-        Get a language property parsing it as a map with string keys.
-
-        .. invisible-code-block: python
-
-            from nunavut.lang import LanguageConfig, LanguageLoader, Language, _GenericLanguage
-
-            config = LanguageConfig()
-            config.add_section('nunavut.lang.c')
-            config.set('nunavut.lang.c', 'foo', {'one': 1})
-
-            lang_c = _GenericLanguage(LanguageLoader.load_language_module('c'), config, True)
-
-            assert lang_c.get_config_value_as_dict('foo')['one'] == 1
-
-            assert lang_c.get_config_value_as_dict('bar', {'one': 2})['one'] == 2
-
-        :param str key:           The config value to retrieve.
-        :param default_value:     The value to return if the key was not in the configuration. If provided this method
-            will not raise a KeyError nor a TypeError.
-        :type default_value: typing.Optional[typing.Mapping[str, typing.Any]]
-        :return:                  Either the value from the config or the default_value if provided.
-        :rtype: typing.Mapping[str, typing.Any]
-        :raises: KeyError if the key does not exist and a default_value was not provided.
-        :raises: TypeError if the value exists but is not a dict and a default_value was not provided.
-
-        """
-        return self._config.get_config_value_as_dict(self._section, key, default_value)
-
-    def get_config_value_as_list(
-        self, key: str, default_value: typing.Optional[typing.List] = None
-    ) -> typing.List[typing.Any]:
-        """
-        Get a language property parsing it as a map with string keys.
-
-        :param str key:           The config value to retrieve.
-        :param default_value:     The value to return if the key was not in the configuration. If provided this method
-            will not raise a KeyError nor a TypeError.
-        :type default_value:      typing.Optional[typing.List[typing.Any]]
-        :return:                  Either the value from the config or the default_value if provided.
-        :rtype:                   typing.List[typing.Any]
-        :raises:                  KeyError if the key does not exist and a default_value was not provided.
-        :raises:                  TypeError if the value exists but is not a dict and a default_value was not provided.
-
-        """
-        return self._config.get_config_value_as_list(self._section, key, default_value)
-
-    @property
-    def extension(self) -> str:
-        """
-        The extension to use for files generated in this language.
-        """
-        return self._config.get_config_value(self._section, "extension", "get")
-
-    @property
-    def namespace_output_stem(self) -> typing.Optional[str]:
-        """
-        The name of a namespace file for this language.
-        """
-        try:
-            return self._config.get_config_value(self._section, "namespace_file_stem")
-        except KeyError:
-            return None
-
-    @property
-    def name(self) -> str:
-        """
-        The name of the language used by the :mod:`nunavut.lang` module.
-        """
-        return self._language_name
-
-    @property
-    def support_namespace(self) -> typing.List[str]:
-        """
-        The hierarchical namespace used by the support software. The property
-        is a dot separated string when specified in configuration. This
-        property returns that value split into namespace components with the
-        first identifier being the first index in the array, etc.
-
-        .. invisible-code-block: python
-
-            from nunavut.lang import Language
-
-            config = {
-                'nunavut.lang.cpp':
-                {
-                    'support_namespace': 'foo.bar'
-                }
-            }
-            lctx = configurable_language_context_factory(config, 'cpp')
-            lang_cpp = lctx.get_target_language()
-
-            assert len(lang_cpp.support_namespace) == 2
-            assert lang_cpp.support_namespace[0] == 'foo'
-            assert lang_cpp.support_namespace[1] == 'bar'
-
-        """
-        namespace_str = self._config.get_config_value(self._section, "support_namespace", default_value="")
-        return namespace_str.split(".")
-
-    @property
-    def enable_stropping(self) -> bool:
-        """
-        Whether or not to strop identifiers for this language.
-        """
-        return self._config.get_config_value_as_bool(self._section, "enable_stropping")
-
-    @property
-    def has_standard_namespace_files(self) -> bool:
-        """
-        Whether or not the language defines special namespace files as part of
-        its core standard (e.g. python's __init__).
-        """
-        return self._config.get_config_value_as_bool(self._section, "has_standard_namespace_files")
-
-    @property
-    def stable_support(self) -> bool:
-        """
-        Whether support for this language is designated 'stable', and not experimental.
-        """
-        return self._config.get_config_value_as_bool(self._section, "stable_support")
-
-    @property
-    def omit_serialization_support(self) -> bool:
-        """
-        If True then generators should not include serialization routines, types,
-        or support libraries for this language.
-        """
-        return self._omit_serialization_support
-
-    def get_support_files(
-        self, resource_type: ResourceType = ResourceType.ANY
-    ) -> typing.Generator[pathlib.Path, None, None]:
-        """
-        Iterates over supporting files embedded within the Nunavut distribution.
-
-        :param resource_type: The type of support resources to enumerate.
-
-        .. invisible-code-block: python
-
-            from nunavut.lang import Language, _GenericLanguage
-            from unittest.mock import MagicMock
-
-            mock_config = MagicMock()
-            mock_module = MagicMock()
-            mock_module.__name__ = 'nunavut.lang.foo'
-
-            my_lang = _GenericLanguage(mock_module, mock_config, True)
-            my_lang._section = "nunavut.lang.not_a_language_really_not_a_language"
-            for support_file in my_lang.get_support_files():
-                # if the module doesn't exist it shouldn't have any support files.
-                assert False
-
-        """
-        _, _, module = self.get_support_module()
-
-        if module is not None:
-            # All language support modules must provide a list_support_files method
-            # to allow the copy generator access to the packaged support files.
-            list_support_files = getattr(
-                module, "list_support_files"
-            )  # type: typing.Callable[[ResourceType], typing.Generator[pathlib.Path, None, None]]
-            return list_support_files(resource_type)
-        else:
-            return empty_list_support_files()
-
-    def get_option(
-        self, option_key: str, default_value: typing.Union[typing.Mapping[str, typing.Any], str, None] = None
-    ) -> typing.Union[typing.Mapping[str, typing.Any], str, None]:
-        """
-        Get a language option for this language.
-
-        .. invisible-code-block: python
-
-            config = {
-                'nunavut.lang.cpp':
-                {
-                    'options': {'target_endianness': 'little'}
-                }
-            }
-            lctx = configurable_language_context_factory(config, 'cpp')
-            lang_cpp = lctx.get_target_language()
-
-        .. code-block:: python
-
-            # Values can come from defaults...
-            assert lang_cpp.get_option('target_endianness') == 'little'
-
-            # ... or can come from a sane default.
-            assert lang_cpp.get_option('foobar', 'sane_default') == 'sane_default'
-
-        :return: Either the value provided to the :class:`Language` instance, the value from properties.yaml,
-            or the :code:`default_value`.
-
-        """
-        try:
-            return self._language_options[option_key]  # type: ignore
-        except KeyError:
-            return default_value
-
-    def get_templates_package_name(self) -> str:
-        """
-        The name of the nunavut python package containing filters, types, and configuration
-        for this language.
-        """
-        return self._section
-
-    def get_named_types(self) -> typing.Mapping[str, str]:
-        """
-        Get a map of named types to the type name to emit for this language.
-        """
-        return self._config.get_config_value_as_dict(self._section, "named_types", default_value={})
-
-    def get_named_values(self) -> typing.Mapping[str, str]:
-        """
-        Get a map of named values to the token to emit for this language.
-        """
-        return self._config.get_config_value_as_dict(self._section, "named_values", default_value={})
-
-    def get_globals(self) -> typing.Mapping[str, typing.Any]:
-        """
-        Get all values for this language that should be available in a global context.
-
-        :return: A mapping of global names to global values.
-        """
-        if self._globals is None:
-            globals_map = dict()  # type: typing.Dict[str, typing.Any]
-
-            for key, value in self.get_named_types().items():
-                globals_map["typename_{}".format(key)] = value
-            for key, value in self.get_named_values().items():
-                globals_map["valuetoken_{}".format(key)] = value
-
-            self._globals = globals_map
-        return self._globals
-
-    def get_options(self) -> typing.Mapping[str, typing.Any]:
-        """
-        Get all language options for this Language.
-
-        :return: A mapping of option names to option values.
-        """
-        return self._language_options
-
-
-class _GenericLanguage(Language):
-    """
-    Language type used when the language support within Nunavut does not define a language-specific
-    subclass.
-
-    Do not use this. Use :class:`nunavut.lang.LanguageLoader` which will create the proper object type
-    based on inspection of the Nunavut internals.
-    """
-
-    def get_includes(self, dep_types: Dependencies) -> typing.List[str]:
-        return []
-
-
-class LanguageContext:
-    """
-    Context object containing the current target language (if any) and used to access
-    :class:`Language` objects.
-
-    :param str target_language: If provided a :class:`Language` object will be created to hold
-                                the target language set for this context. If None then there is
-                                no target language.
-    :param str extension: The extension to use for generated file types or None to use a default
-                          based on the target_language.
-    :param str namespace_output_stem: The filename stem to give to Namespace output files if
-                                      emitted or None to use a default based on a target_language.
-    :param additional_config_files: A list of paths to additional files to load as configuration.
-        These will override any values found in the :file:`nunavut.lang.properties.yaml` file and files
-        appearing later in this list will override value found in earlier entries.
-    :type additional_config_files: typing.List[pathlib.Path]
-    :param bool omit_serialization_support_for_target: If True then generators should not include
-        serialization routines, types, or support libraries for the target language.
-    :param typing.Optional[typing.Mapping[str, typing.Any]] language_options: Opaque arguments passed through to the
-                target :class:`nunavut.lang.Language` object.
-    :param bool include_experimental_languages: If True, expose languages with experimental (non-stable) support.
-    :raises ValueError: If extension is None and no target language was provided.
-    :raises KeyError: If the target language is not known.
-    """
-
-    def __init__(
-        self,
-        target_language: typing.Optional[str] = None,
-        extension: typing.Optional[str] = None,
-        namespace_output_stem: typing.Optional[str] = None,
-        additional_config_files: typing.List[pathlib.Path] = [],
-        omit_serialization_support_for_target: bool = True,
-        language_options: typing.Optional[typing.Mapping[str, typing.Any]] = None,
-        include_experimental_languages: bool = True,
-    ):
-        self._extension = extension
-        self._namespace_output_stem = namespace_output_stem
-        self._ln_loader = LanguageLoader(*additional_config_files)
-        self._config = self._ln_loader.config
-        self._languages = dict()  # type: typing.Dict[str, Language]
-
-        # create target language, if there is one.
-        self._target_language = None
-        if target_language is not None:
-            try:
-                self._target_language = self._ln_loader.load_language(
-                    target_language, omit_serialization_support_for_target, language_options=language_options
-                )
-            except ImportError:
-                raise KeyError("{} is not a supported language".format(target_language))
-            if not (self._target_language.stable_support or include_experimental_languages):
-                raise ValueError(
-                    "{} support is only experimental, but experimental language support is not enabled".format(
-                        target_language
-                    )
-                )
-            if namespace_output_stem is None:
-                self._namespace_output_stem = self._target_language.namespace_output_stem
-
-            target_language_section_name = "nunavut.lang.{}".format(target_language)
-            if self._namespace_output_stem is not None:
-                self._config.set(target_language_section_name, "namespace_file_stem", self._namespace_output_stem)
-            if extension is not None:
-                self._config.set(target_language_section_name, "extension", extension)
-            self._languages[target_language] = self._target_language
-
-        # create remaining languages
-        remaining_languages = set(self.get_supported_language_names()) - set((target_language,))
-        self._populate_languages(remaining_languages, include_experimental_languages)
-
-    def _populate_languages(self, language_names: typing.Iterable[str], include_experimental: bool) -> None:
-        for language_name in language_names:
-            try:
-                lang = self._ln_loader.load_language(language_name, False)
-                if lang.stable_support or include_experimental:
-                    self._languages[language_name] = lang
-            except ImportError:
-                raise KeyError("{} is not a supported language".format(language_name))
-
-    def get_language(self, key_or_module_name: str) -> Language:
-        """
-        Get a :class:`Language` object for a given language identifier.
-
-        :param str key_or_module_name: Either one of the Nunavut mnemonics for a supported language or
-            the ``__name__`` of one of the ``nunavut.lang.[language]`` python modules.
-        :return: A :class:`Language` object cached by this context.
-        :rtype: Language
-        """
-        if key_or_module_name is None or len(key_or_module_name) == 0:
-            raise ValueError("key argument is required.")
-        key = key_or_module_name[13:] if key_or_module_name.startswith("nunavut.lang.") else key_or_module_name
-        return self.get_supported_languages()[key]
+    DEFAULT_TARGET_LANGUAGE = "c"
+
+    def __init__(self, include_experimental_languages: bool = False):
+        self._target_language_name: typing.Optional[str] = None
+        self._target_language_config: typing.Dict[str, str] = {}
+        self._ln_loader = LanguageClassLoader()
+        self._include_experimental_languages = include_experimental_languages
 
     def get_supported_language_names(self) -> typing.Iterable[str]:
-        """Get a list of target languages supported by Nunavut.
+        """
+        Get a list of target languages supported by Nunavut.
 
         :return: An iterable of strings which are languages with special
             support within Nunavut templates.
         """
-        return [s[13:] for s in self._config.sections() if s.startswith("nunavut.lang.")]
+        return [LanguageClassLoader.to_language_name(s) for s in self._ln_loader.config.sections()]
 
-    def get_output_extension(self) -> str:
-        """
-        Gets the output extension to use regardless of a target language being available or not.
+    @property
+    def config(self) -> LanguageConfig:
+        return self._ln_loader.config
 
-        :return: A file extension name with a leading dot.
+    # +-----------------------------------------------------------------------+
+    # | BUILDER SYNTAX
+    # +-----------------------------------------------------------------------+
+
+    def set_target_language_configuration_override(self, key: str, value: typing.Any) -> "LanguageContextBuilder":
         """
-        if self._extension is not None:
-            return self._extension
-        elif self._target_language is not None:
-            return self._target_language.extension
-        else:
-            raise RuntimeError(
-                "No extension was provided and no target language was set. Cannot determine the extension to use."
+        Stores a key and value to override in the configuration for a language target when a LanguageContext is crated.
+        These overrides are always set under the language section of the target langauge.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import LanguageContextBuilder, Language, LanguageClassLoader
+
+        .. code-block:: python
+
+            builder = LanguageContextBuilder().set_target_language("c")
+
+            default_c_file_extension = builder.config.get_config_value(
+                                            LanguageClassLoader.to_language_module_name("c"),
+                                            Language.WKCV_DEFINITION_FILE_EXTENSION)
+
+            assert default_c_file_extension == ".h"
+
+        We can now try to override the file extension for a future "C" target language object:
+
+        .. code-block:: python
+
+            builder.set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".foo")
+
+        ...but that value will not be overriden until you create the target language:
+
+        .. code-block:: python
+
+            default_c_file_extension = builder.config.get_config_value(
+                                            LanguageClassLoader.to_language_module_name("c"),
+                                            Language.WKCV_DEFINITION_FILE_EXTENSION)
+
+            assert default_c_file_extension == ".h"
+
+            _ = builder.create()
+
+            overridden_c_file_extension = builder.config.get_config_value(
+                                            LanguageClassLoader.to_language_module_name("c"),
+                                            Language.WKCV_DEFINITION_FILE_EXTENSION)
+
+            assert overridden_c_file_extension == ".foo"
+
+        Note that the config is scoped by the builder but is then inherited by the langauge objects created by the
+        builder:
+
+        .. code-block:: python
+
+            one = (
+                LanguageContextBuilder()
+                    .set_target_language("c")
+                    .set_target_language_configuration_override("foo", 1)
+                )
+            two = (
+                LanguageContextBuilder()
+                    .set_target_language("c")
+                    .set_target_language_configuration_override("foo", 2)
+                )
+
+            # Here we see that the second override of "foo" does not affect the first because they
+            # are in different builders.
+
+            assert (
+                    one.create().get_target_language().get_config_value("foo")
+                    !=
+                    two.create().get_target_language().get_config_value("foo")
+                )
+
+        """
+        if value is not None:
+            self._target_language_config[key] = value
+        return self
+
+    def set_target_language_extension(
+        self, target_language_extension: typing.Optional[str]
+    ) -> "LanguageContextBuilder":
+        """
+        Helper method for setting the target language file extension (since this is a common override).
+
+        Calling this method is the same as doing:
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import LanguageContextBuilder, Language, LanguageClassLoader
+
+        .. code-block:: python
+
+            LanguageContextBuilder().set_target_language_configuration_override(
+                Language.WKCV_DEFINITION_FILE_EXTENSION,
+                ".h")
+
+        """
+        return self.set_target_language_configuration_override(
+            Language.WKCV_DEFINITION_FILE_EXTENSION, target_language_extension
+        )
+
+    def set_target_language(self, target_language: typing.Optional[str]) -> "LanguageContextBuilder":
+        """
+        Set the language name to target. This can be either the name of the language, as defined by Nunavut, or
+        it can be the language package name.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import LanguageContextBuilder, LanguageClassLoader
+
+        .. code-block:: python
+
+            assert LanguageContextBuilder().set_target_language("c").create().get_target_language().name == "c"
+
+            assert (
+                LanguageContextBuilder()
+                    .set_target_language(LanguageClassLoader.to_language_module_name("c"))
+                    .create()
+                    .get_target_language().name == "c"
             )
 
-    def get_default_namespace_output_stem(self) -> typing.Optional[str]:
-        """
-        The filename stem to give to Namespace output files if emitted or None if there was none
-        specified and there is no target language.
+        Also note that, if the language name is None, the default name will be assigned internally:
 
-        :return: A file name stem or None
-        """
-        return self._namespace_output_stem
+        .. code-block:: python
 
-    def get_target_language(self) -> typing.Optional[Language]:
+            target_language = LanguageContextBuilder().set_target_language(None).create().get_target_language()
+
+            assert target_language.name == LanguageContextBuilder.DEFAULT_TARGET_LANGUAGE
+
         """
-        Returns the target language configured on this object or None
-        if no target language was specified.
+        if target_language is None:
+            self._target_language_name = self.DEFAULT_TARGET_LANGUAGE
+        else:
+            self._target_language_name = LanguageClassLoader.to_language_name(target_language)
+        return self
+
+    def set_additional_config_files(
+        self, additional_config_files: typing.List[pathlib.Path]
+    ) -> "LanguageContextBuilder":
+        """
+        A list of paths to additional yaml files to load as configuration.
+        These will override any values found in the :file:`nunavut.lang.properties.yaml` file and files
+        appearing later in this list will override value found in earlier entries.
+
+        .. invisible-code-block: python
+
+            import pathlib
+            import yaml
+            import textwrap
+            from nunavut.lang import LanguageContextBuilder, Language, LanguageClassLoader
+
+            overrides_file = gen_paths.out_dir / pathlib.Path("overrides1.yaml")
+
+            overrides_data = {LanguageClassLoader.to_language_module_name("c"):
+                {Language.WKCV_DEFINITION_FILE_EXTENSION: ".foo"}
+            }
+
+            with open(overrides_file, "w") as overrides_handle:
+                yaml.dump(overrides_data, overrides_handle)
+
+        .. code-block:: python
+
+            target_language_w_overrides = (
+                LanguageContextBuilder()
+                    .set_target_language("c")
+                    .set_additional_config_files([overrides_file])
+                    .create()
+                    .get_target_language()
+            )
+
+            target_language_no_overrides = (
+                LanguageContextBuilder()
+                    .set_target_language("c")
+                    .create()
+                    .get_target_language()
+            )
+
+            assert target_language_w_overrides.extension == ".foo"
+            assert target_language_no_overrides.extension == ".h"
+
+        Overrides are applies as unions. For example, given this override data:
+
+        .. code-block:: python
+
+            overrides_data = '''
+                nunavut.lang.c:
+                    extension: .foo
+                    non-standard: bar
+            '''
+
+        ...the standard "extension" property will be overridden and the "non-standard" property will be added.
+
+        .. invisible-code-block: python
+
+            second_overrides_file = gen_paths.out_dir / pathlib.Path("overrides2.yaml")
+            with open(second_overrides_file, "w") as overrides_handle:
+                overrides_handle.write(textwrap.dedent(overrides_data))
+
+        .. code-block:: python
+
+            target_language_w_overrides = (
+                LanguageContextBuilder()
+                    .set_target_language("c")
+                    .set_additional_config_files([second_overrides_file])
+                    .create()
+                    .get_target_language()
+            )
+
+            assert ".foo" == target_language_w_overrides.extension
+            assert "bar" == target_language_w_overrides.get_config_value("non-standard")
+
+        """
+        for additional_path in additional_config_files:
+            with open(str(additional_path), "r") as additional_file:
+                self._ln_loader.config.update_from_file(additional_file)
+
+        return self
+
+    def create(self) -> "LanguageContext":
+        """
+        Applies all pending configuration overrides to the internal :class:`LanguageConfig` object and instatiates
+        a :class:`LanguageContext` object.
+        """
+        # First find the target language to use...
+        target_language_name = self._resolve_target_language(self._target_language_name)
+
+        # Now update the configuration for the target language with everything we stored in this
+        # builder instance...
+        self.config.update_section(
+            LanguageClassLoader.to_language_module_name(target_language_name), self._target_language_config
+        )
+
+        # Create the target language instance...
+        target_language = self._new_language_w_experimental_handling(target_language_name)
+
+        # and finally, build the LanguageContext.
+        return LanguageContext(
+            self._ln_loader.config, target_language, functools.partial(self._new_language_map, target_language)
+        )
+
+    # +-----------------------------------------------------------------------+
+    # | PRIVATE
+    # +-----------------------------------------------------------------------+
+    def _new_language_w_experimental_handling(self, language_name: str) -> Language:
+        try:
+            language = self._ln_loader.new_language(language_name)
+        except ImportError as e:
+            logger.debug("Import Error {} when trying to load language {}".format(str(e), language_name))
+            raise KeyError("language {} is not a supported language".format(language_name))
+        if not (language.stable_support or self._include_experimental_languages):
+            raise UnsupportedLanguageError(
+                "{} support is only experimental, but experimental language support is not enabled".format(
+                    language_name
+                )
+            )
+        return language
+
+    def _new_language_map(self, target_language: Language) -> typing.Dict[str, Language]:
+        """
+        Build a map of all supported languages.
+        :param target_language: The target language is included in the returned map but must be build
+            by another method.
+        """
+        languages: typing.Dict[str, Language] = {target_language.name: target_language}
+        for language_name in set(self.get_supported_language_names()) - set((target_language.name,)):
+            try:
+                languages[language_name] = self._new_language_w_experimental_handling(language_name)
+            except UnsupportedLanguageError:
+                pass
+        return languages
+
+    def _resolve_target_language(self, explicit_value: typing.Optional[str]) -> str:
+
+        if explicit_value is not None:
+            return explicit_value
+
+        inferred_target_language_name: typing.Optional[str] = None
+
+        target_extension = self._target_language_config.get(Language.WKCV_DEFINITION_FILE_EXTENSION, None)
+        if target_extension is not None:
+            for language_config_section_name, language_config_section in self.config.sections().items():
+                if language_config_section.get("extension", None) == target_extension:
+                    inferred_target_language_name = LanguageClassLoader.to_language_name(language_config_section_name)
+                    break
+
+        if inferred_target_language_name is None:
+            inferred_target_language_name = self.DEFAULT_TARGET_LANGUAGE
+            logger.info(
+                "No target language specified and none could be inferred. Using default language, {}".format(
+                    self.DEFAULT_TARGET_LANGUAGE
+                )
+            )
+        else:
+            logging.info(
+                'Inferring target language %s based on extension "%s".',
+                inferred_target_language_name,
+                target_extension,
+            )
+        return inferred_target_language_name
+
+
+class LanguageContext:
+    """
+    Context object containing the current target language and all supported :class:`nunavut.lang.Language` objects.
+
+    :param language_configuration: The configuration for all languages as defined by the properties.yaml schema.
+    :param target_language: The target language.
+    :param supported_language_builder: factory closure that will create :class:`nunavut.lang.Language` objects for
+                                       all supported languages when :func:`LanguageContext.get_target_languages`
+                                       is first called.
+    """
+
+    def __init__(
+        self,
+        language_configuration: LanguageConfig,
+        target_language: Language,
+        supported_language_builder: typing.Callable[[], typing.Dict[str, Language]],
+    ):
+        self._config = language_configuration
+        self._target_language = target_language
+        self._all_supported_languages: typing.Optional[typing.Dict[str, Language]] = None
+        self._all_supported_languages_builder = supported_language_builder
+
+    def get_language(self, key_or_module_name: str) -> Language:
+        """
+        Get a :class:`nunavut.lang.Language` object for a given language identifier.
+
+        :param str key_or_module_name: Either one of the Nunavut mnemonics for a supported language or
+            the ``__name__`` of one of the ``nunavut.lang.[language]`` python modules.
+        :return: A :class:`nunavut.lang.Language` object cached by this context.
+        :rtype: nunavut.lang.Language
+        """
+        if key_or_module_name is None or len(key_or_module_name) == 0:
+            raise ValueError("key argument is required.")
+        key = LanguageClassLoader.to_language_name(key_or_module_name)
+        return self.get_supported_languages()[key]
+
+    def get_target_language(self) -> Language:
+        """
+        Returns the target language for code generation.
         """
         return self._target_language
 
     def filter_id_for_target(self, instance: typing.Any, id_type: str = "any") -> str:
         """
         A filter that will transform a given string or pydsdl identifier into a valid identifier in the target language.
-        A default transformation is applied if no target language is set.
 
         :param any instance:        Any object or data that either has a name property or can be converted to a string.
         :param str id_type:         A type of identifier. This is different for each language.
@@ -738,16 +438,33 @@ class LanguageContext:
         :return: A token that is a valid identifier in the target language, is not a reserved keyword, and is
                  transformed in a deterministic manner based on the provided instance.
         """
-        if self._target_language is not None:
-            return self._target_language.filter_id(instance, id_type)
-        else:
-            return Language.default_filter_id_for_target(instance)
+        return self._target_language.filter_id(instance, id_type)
 
     def get_supported_languages(self) -> typing.Dict[str, Language]:
         """
         Returns a collection of available language support objects.
+
+         .. invisible-code-block: python
+
+            from nunavut.lang import LanguageContextBuilder
+
+            lctx = LanguageContextBuilder().create()
+
+            default_language = None
+
+            for language_name, language in lctx.get_supported_languages().items():
+                if language_name == LanguageContextBuilder.DEFAULT_TARGET_LANGUAGE:
+                    default_language = language
+                    break
+
+            assert default_language is not None
+            assert default_language.name == LanguageContextBuilder.DEFAULT_TARGET_LANGUAGE
+            assert len(lctx.get_supported_languages()) > 1
+
         """
-        return self._languages
+        if self._all_supported_languages is None:
+            self._all_supported_languages = self._all_supported_languages_builder()
+        return self._all_supported_languages
 
     @property
     def config(self) -> LanguageConfig:

--- a/src/nunavut/lang/_config.py
+++ b/src/nunavut/lang/_config.py
@@ -12,6 +12,7 @@ import typing
 
 from yaml import Loader as YamlLoader
 from yaml import load as yaml_loader
+from .._utilities import deep_update
 
 
 class LanguageConfig:
@@ -39,7 +40,7 @@ class LanguageConfig:
         from nunavut.lang import LanguageConfig
 
         config = LanguageConfig()
-        config.read_string(example_yaml)
+        config.update_from_string(example_yaml)
 
         data = config.sections()
         assert len(data) == 3
@@ -67,7 +68,7 @@ class LanguageConfig:
 
     .. invisible-code-block: python
 
-        config.read_string(example_yaml)
+        config.update_from_string(example_yaml)
         assert 'a_dictionary' == config.sections()['nunavut.lang.d']['key_one'][2]['list']['is']
 
     """
@@ -208,21 +209,19 @@ class LanguageConfig:
                 raise ValueError(
                     'Section name "{}" is invalid. See LanguageConfig documentation for rules.'.format(section_name)
                 )
-            try:
-                section = self._sections[section_name]
-            except KeyError:
-                self._sections[section_name] = dict()
-                section = self._sections[section_name]
-            section.update(section_data)
+            self.update_section(section_name, section_data)
+
+    def update_section(self, section_name: str, configuration: typing.Any) -> None:
+        self._sections[section_name] = deep_update(self._sections.get(section_name, {}), configuration)
 
     def sections(self) -> typing.Dict[str, typing.Dict[str, typing.Any]]:
         return self._sections
 
-    def read_string(self, string: str, context: typing.Optional[str] = None) -> None:
+    def update_from_string(self, string: str, context: typing.Optional[str] = None) -> None:
         configuration = yaml_loader(string, Loader=YamlLoader)
         self.update(configuration)
 
-    def read_file(self, f: typing.TextIO, context: typing.Optional[str] = None) -> None:
+    def update_from_file(self, f: typing.TextIO, context: typing.Optional[str] = None) -> None:
         configuration = yaml_loader(f, Loader=YamlLoader)
         self.update(configuration)
 

--- a/src/nunavut/lang/_language.py
+++ b/src/nunavut/lang/_language.py
@@ -1,0 +1,674 @@
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright (C) 2018-2022  OpenCyphal Development Team  <opencyphal.org>
+# This software is distributed under the terms of the MIT License.
+#
+"""
+Language-specific support in nunavut.
+
+This module contains the Language object and supporting types.
+"""
+import abc
+import functools
+import importlib
+import logging
+import pathlib
+import types
+import typing
+
+import pydsdl
+
+from .._utilities import ResourceType, YesNoDefault, empty_list_support_files, iter_package_resources
+from ..dependencies import Dependencies, DependencyBuilder
+from ._config import LanguageConfig, VersionReader
+
+logger = logging.getLogger(__name__)
+
+
+# +---------------------------------------------------------------------------+
+# | ABSTRACT LANGUAGE
+# +---------------------------------------------------------------------------+
+
+
+class Language(metaclass=abc.ABCMeta):
+    """
+    Facilities for generating source code for a specific language. Concrete Language classes must be implemented
+    by the language support package below lang and should be instantiated using
+    :class:`nunavut.lang.LanguageClassLoader`.
+
+    :param str module_name:                  The name of the :mod:`nunavut.lang` module that contains the concrete
+                                             language type and its resources.
+    :param LanguageConfig config:            All configuration as defined by the properties.yaml schema.
+    :param kwargs:                           Opaque arguments passed through to the target
+                                             :class:`nunavut.lang.Language` object. See all "WKLA" constants
+                                             on this class for well-known keyword arguments.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang._language import Language
+            from nunavut.lang._language import _GenericLanguage
+            from unittest.mock import MagicMock
+
+            mock_config = MagicMock()
+
+            try:
+                my_lang = _GenericLanguage("foo", mock_config)
+                # module must be within 'nunavut'
+                assert False
+            except RuntimeError:
+                pass
+
+            try:
+                my_lang = _GenericLanguage("nunavut.foo", mock_config)
+                # module must be within 'nunavut.lang'
+                assert False
+            except RuntimeError:
+                pass
+
+            try:
+                my_lang = _GenericLanguage("not.nunavut.foo", mock_config)
+                # module must be within 'nunavut.lang'
+                assert False
+            except RuntimeError:
+                pass
+
+            my_lang = _GenericLanguage("nunavut.lang.foo", mock_config)
+            assert my_lang.name == 'foo'
+    """
+
+    # Well-Known Configuration Values (WKCV)
+    # These are language configuration values the base Language class will look for.
+    WKCV_DEFINITION_FILE_EXTENSION = "extension"
+    WKCV_NAMESPACE_FILE_STEM = "namespace_file_stem"
+    WKCV_SUPPORT_NAMESPACE = "support_namespace"
+    WKCV_ENABLE_STROPPING = "enable_stropping"
+    WKCV_HAS_STANDARD_NAMESPACE_FILES = "has_standard_namespace_files"
+    WKCV_STABLE_SUPPORT = "stable_support"
+    WKCV_NAMED_TYPES = "named_types"
+    WKCV_NAMED_VALUES = "named_values"
+    WKCV_LANGUAGE_OPTIONS = "options"
+
+    @classmethod
+    def default_filter_id_for_target(cls, instance: typing.Any) -> str:
+        """
+        The default transformation of any object into a string.
+
+        :param any instance:        Any object or data that either has a name property or can be converted to a string.
+        :return: Either ``str(instance.name)`` if the instance has a name property or just ``str(instance)``
+        """
+        if hasattr(instance, "name"):
+            return str(instance.name)
+        else:
+            return str(instance)
+
+    # +-----------------------------------------------------------------------+
+    # | LIFECYCLE AND DATA MODEL
+    # +-----------------------------------------------------------------------+
+
+    def __init__(self, language_module_name: str, config: LanguageConfig, **kwargs: typing.Any):
+        self._globals = None  # type: typing.Optional[typing.Mapping[str, typing.Any]]
+        self._section = language_module_name
+        if not self._section.startswith(LanguageClassLoader.MODULE_PREFIX):
+            raise RuntimeError("Unknown module name for language: {}".format(self._section))
+        self._language_name = LanguageClassLoader.to_language_name(self._section)
+        self._config = config
+        self._language_options = config.get_config_value_as_dict(self._section, self.WKCV_LANGUAGE_OPTIONS, dict())
+        self._filters = dict()  # type: typing.Dict[str, typing.Callable]
+        self._tests = dict()  # type: typing.Dict[str, typing.Callable]
+        self._uses = dict()  # type: typing.Dict[str, typing.Callable]
+
+    def __getattr__(self, name: str) -> typing.Any:
+        """
+        Any attribute access to a Language object will return the regular properties and
+        any globals defined for the language. Because of this do not extend properties
+        on this object in a way that will clash with the globals it defines (e.g. typename_
+        or valuetoken_ should not be used as the start of attribute names).
+        """
+        try:
+            return self.get_globals()[name]
+        except KeyError as e:
+            raise AttributeError(e)
+
+    # +-----------------------------------------------------------------------+
+    # | PROPERTIES
+    # +-----------------------------------------------------------------------+
+    @property
+    def extension(self) -> str:
+        """
+        The extension to use for files generated in this language.
+        """
+        return self._config.get_config_value(self._section, self.WKCV_DEFINITION_FILE_EXTENSION)
+
+    @property
+    def namespace_output_stem(self) -> typing.Optional[str]:
+        """
+        The name of a namespace file for this language.
+        """
+        return self._config.get_config_value(self._section, self.WKCV_NAMESPACE_FILE_STEM, None)
+
+    @property
+    def name(self) -> str:
+        """
+        The name of the language used by the :mod:`nunavut.lang` module.
+        """
+        return self._language_name
+
+    @property
+    def support_namespace(self) -> typing.List[str]:
+        """
+        The hierarchical namespace used by the support software. The property
+        is a dot separated string when specified in configuration. This
+        property returns that value split into namespace components with the
+        first identifier being the first index in the array, etc.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import Language, LanguageContextBuilder
+
+            lang_cpp = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                    .set_target_language("cpp")
+                    .set_target_language_configuration_override(Language.WKCV_SUPPORT_NAMESPACE, "foo.bar")
+                    .create()
+                    .get_target_language()
+            )
+
+            assert len(lang_cpp.support_namespace) == 2
+            assert lang_cpp.support_namespace[0] == 'foo'
+            assert lang_cpp.support_namespace[1] == 'bar'
+
+        """
+        namespace_str = self._config.get_config_value(self._section, self.WKCV_SUPPORT_NAMESPACE, default_value="")
+        return namespace_str.split(".")
+
+    @property
+    def enable_stropping(self) -> bool:
+        """
+        Whether or not to strop identifiers for this language.
+        """
+        return self._config.get_config_value_as_bool(self._section, self.WKCV_ENABLE_STROPPING)
+
+    @property
+    def has_standard_namespace_files(self) -> bool:
+        """
+        Whether or not the language defines special namespace files as part of
+        its core standard (e.g. python's __init__).
+        """
+        return self._config.get_config_value_as_bool(self._section, self.WKCV_HAS_STANDARD_NAMESPACE_FILES)
+
+    @property
+    def stable_support(self) -> bool:
+        """
+        Whether support for this language is designated 'stable', and not experimental.
+        """
+        return self._config.get_config_value_as_bool(self._section, self.WKCV_STABLE_SUPPORT)
+
+    @property
+    def named_types(self) -> typing.Mapping[str, str]:
+        """
+        Get a map of named types to the type name to emit for this language.
+        """
+        return self._config.get_config_value_as_dict(self._section, self.WKCV_NAMED_TYPES, default_value={})
+
+    @property
+    def named_values(self) -> typing.Mapping[str, str]:
+        """
+        Get a map of named values to the token to emit for this language.
+        """
+        return self._config.get_config_value_as_dict(self._section, self.WKCV_NAMED_VALUES, default_value={})
+
+    # +-----------------------------------------------------------------------+
+    # | METHODS
+    # +-----------------------------------------------------------------------+
+
+    def get_support_module(self) -> typing.Tuple[str, typing.Tuple[int, int, int], typing.Optional["types.ModuleType"]]:
+        """
+        Returns the module object for the language support files.
+        :return: A tuple of module name, x.y.z module version, and the module object itself.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang._language import Language, _GenericLanguage, LanguageConfig
+            from unittest.mock import MagicMock
+
+            mock_config = MagicMock()
+            mock_module_name= LanguageClassLoader.to_language_module_name("cpp")
+
+            my_lang = _GenericLanguage(mock_module_name, mock_config)
+            my_lang._section = LanguageClassLoader.to_language_module_name("cpp")
+            module_name, support_version, _ = my_lang.get_support_module()
+
+            assert module_name == LanguageClassLoader.to_language_module_name("cpp") + ".support"
+            assert support_version[0] == 1
+
+        """
+        module_name = "{}.support".format(self._section)
+
+        try:
+            module = importlib.import_module(module_name)
+            version_tuple = VersionReader.read_version(module)
+            return (module_name, version_tuple, module)
+        except (ImportError, ValueError):
+            # No serialization support for this language
+            logger.info("No serialization support for selected target. Cannot retrieve module.")
+
+            return (module_name, (0, 0, 0), None)
+
+    @functools.lru_cache()
+    def get_dependency_builder(self, for_type: pydsdl.Any) -> DependencyBuilder:
+        return DependencyBuilder(for_type)
+
+    @abc.abstractmethod
+    def get_includes(self, dep_types: Dependencies) -> typing.List[str]:
+        """
+        Get a list of include paths that are specific to this language and the options set for it.
+        :param Dependencies dep_types: A description of the dependencies includes are needed for.
+        :return: A list of include file paths. The list may be empty if no includes were needed.
+        """
+        pass
+
+    def filter_id(self, instance: typing.Any, id_type: str = "any") -> str:
+        """
+        Produces a valid identifier in the language for a given object. The encoding may not be reversible.
+
+        :param any instance:        Any object or data that either has a name property or can be converted
+                                    to a string.
+        :param str id_type:         A type of identifier. This is different for each language. For example, for C this
+                                    value can be 'typedef', 'macro', 'function', or 'enum'.
+                                    Use 'any' to apply stropping rules for all identifier types to the instance.
+        :return: A token that is a valid identifier in the language, is not a reserved keyword, and is transformed
+                in a deterministic manner based on the provided instance.
+        """
+        return self.default_filter_id_for_target(instance)
+
+    def filter_short_reference_name(
+        self, t: pydsdl.CompositeType, stropping: YesNoDefault = YesNoDefault.DEFAULT, id_type: str = "any"
+    ) -> str:
+        """
+        Provides a string that is a shorted version of the full reference name omitting any namespace parts of the type.
+
+        :param pydsdl.CompositeType t: The DSDL type to get the reference name for.
+        :param YesNoDefault stropping: If DEFAULT then the stropping value configured for the target language is used
+                                       else this overrides that value.
+        :param str id_type:         A type of identifier. This is different for each language. For example, for C this
+                                    value can be 'typedef', 'macro', 'function', or 'enum'.
+                                    Use 'any' to apply stropping rules for all identifier types to the instance.
+        """
+        short_name = "{short}_{major}_{minor}".format(short=t.short_name, major=t.version.major, minor=t.version.minor)
+        if YesNoDefault.test_truth(stropping, self.enable_stropping):
+            return self.filter_id(short_name, id_type)
+        else:
+            return short_name
+
+    def get_config_value(self, key: str, default_value: typing.Optional[str] = None) -> str:
+        """
+        Get an optional language property from the language configuration.
+
+        :param str key: The config value to retrieve.
+        :param default_value: The value to return if the key was not in the configuration. If provided
+                this method will not raise.
+        :type default_value: typing.Optional[str]
+        :return: Either the value from the config or the default_value if provided.
+        :rtype: str
+        :raises: KeyError if the section or the key in the section does not exist and a default_value was not provided.
+        """
+        return self._config.get_config_value(self._section, key, default_value)
+
+    def get_config_value_as_bool(self, key: str, default_value: bool = False) -> bool:
+        """
+        Get an optional language property from the language configuration returning a boolean.
+
+        :param str key: The config value to retrieve.
+        :param bool default_value: The value to use if no value existed.
+        :return: The config value as either True or False.
+        :rtype: bool
+        """
+        return self._config.get_config_value_as_bool(self._section, key, default_value)
+
+    def get_config_value_as_dict(
+        self, key: str, default_value: typing.Optional[typing.Dict] = None
+    ) -> typing.Dict[str, typing.Any]:
+        """
+        Get a language property parsing it as a map with string keys.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang._language import LanguageConfig, LanguageClassLoader, Language, _GenericLanguage
+
+            config = LanguageConfig()
+            config.add_section('nunavut.lang.c')
+            config.set('nunavut.lang.c', 'foo', {'one': 1})
+
+            lang_c = _GenericLanguage(LanguageClassLoader.to_language_module_name('c'), config)
+
+            assert lang_c.get_config_value_as_dict('foo')['one'] == 1
+
+            assert lang_c.get_config_value_as_dict('bar', {'one': 2})['one'] == 2
+
+        :param str key:           The config value to retrieve.
+        :param default_value:     The value to return if the key was not in the configuration. If provided this method
+            will not raise a KeyError nor a TypeError.
+        :type default_value: typing.Optional[typing.Mapping[str, typing.Any]]
+        :return:                  Either the value from the config or the default_value if provided.
+        :rtype: typing.Mapping[str, typing.Any]
+        :raises: KeyError if the key does not exist and a default_value was not provided.
+        :raises: TypeError if the value exists but is not a dict and a default_value was not provided.
+
+        """
+        return self._config.get_config_value_as_dict(self._section, key, default_value)
+
+    def get_config_value_as_list(
+        self, key: str, default_value: typing.Optional[typing.List] = None
+    ) -> typing.List[typing.Any]:
+        """
+        Get a language property parsing it as a map with string keys.
+
+        :param str key:           The config value to retrieve.
+        :param default_value:     The value to return if the key was not in the configuration. If provided this method
+            will not raise a KeyError nor a TypeError.
+        :type default_value:      typing.Optional[typing.List[typing.Any]]
+        :return:                  Either the value from the config or the default_value if provided.
+        :rtype:                   typing.List[typing.Any]
+        :raises:                  KeyError if the key does not exist and a default_value was not provided.
+        :raises:                  TypeError if the value exists but is not a dict and a default_value was not provided.
+
+        """
+        return self._config.get_config_value_as_list(self._section, key, default_value)
+
+    def get_support_files(
+        self, resource_type: ResourceType = ResourceType.ANY
+    ) -> typing.Generator[pathlib.Path, None, None]:
+        """
+        Iterates over supporting files embedded within the Nunavut distribution.
+
+        :param resource_type: The type of support resources to enumerate.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang._language import Language, _GenericLanguage, LanguageClassLoader
+            from unittest.mock import MagicMock
+
+            mock_config = MagicMock()
+            mock_module_name_ = LanguageClassLoader.to_language_module_name("foo")
+
+            my_lang = _GenericLanguage(mock_module_name_, mock_config)
+            my_lang._section =  LanguageClassLoader.to_language_module_name("not_a_language_really_not_a_language")
+            for support_file in my_lang.get_support_files():
+                # if the module doesn't exist it shouldn't have any support files.
+                assert False
+
+        """
+        _, _, module = self.get_support_module()
+
+        if module is not None:
+            # All language support modules must provide a list_support_files method
+            # to allow the copy generator access to the packaged support files.
+            list_support_files = getattr(
+                module, "list_support_files"
+            )  # type: typing.Callable[[ResourceType], typing.Generator[pathlib.Path, None, None]]
+            return list_support_files(resource_type)
+        else:
+            return empty_list_support_files()
+
+    def get_option(
+        self, option_key: str, default_value: typing.Union[typing.Mapping[str, typing.Any], str, None] = None
+    ) -> typing.Union[typing.Mapping[str, typing.Any], str, None]:
+        """
+        Get a language option for this language.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import Language, LanguageContextBuilder
+
+            options = {'target_endianness': 'little'}
+
+            lang_cpp = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                    .set_target_language("cpp")
+                    .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                    .create()
+                    .get_target_language()
+            )
+
+        .. code-block:: python
+
+            # Values can come from defaults...
+            assert lang_cpp.get_option('target_endianness') == 'little'
+
+            # ... or can come from a sane default.
+            assert lang_cpp.get_option('foobar', 'sane_default') == 'sane_default'
+
+        :return: Either the value provided to the :class:`nunavut.lang.Language` instance, the value from
+            properties.yaml or the :code:`default_value`.
+
+        """
+        try:
+            return self._language_options[option_key]  # type: ignore
+        except KeyError:
+            return default_value
+
+    def get_templates_package_name(self) -> str:
+        """
+        The name of the nunavut python package containing filters, types, and configuration
+        for this language.
+        """
+        return self._section
+
+    def get_globals(self) -> typing.Mapping[str, typing.Any]:
+        """
+        Get all values for this language that should be available in a global context.
+
+        :return: A mapping of global names to global values.
+        """
+        if self._globals is None:
+            globals_map = dict()  # type: typing.Dict[str, typing.Any]
+
+            for key, value in self.named_types.items():
+                globals_map["typename_{}".format(key)] = value
+            for key, value in self.named_values.items():
+                globals_map["valuetoken_{}".format(key)] = value
+
+            self._globals = globals_map
+        return self._globals
+
+    def get_options(self) -> typing.Mapping[str, typing.Any]:
+        """
+        Get all language options for this Language.
+
+        :return: A mapping of option names to option values.
+        """
+        return self._language_options
+
+
+# +---------------------------------------------------------------------------+
+# | UNDEFINED LANGUAGE TYPE (concrete)
+# +---------------------------------------------------------------------------+
+
+
+class _GenericLanguage(Language):
+    """
+    Language type used when the language support within Nunavut does not define a language-specific
+    subclass.
+
+    Do not use this. Use :class:`nunavut.lang.LanguageClassLoader` which will create the proper object type
+    based on inspection of the Nunavut internals.
+    """
+
+    def get_includes(self, dep_types: Dependencies) -> typing.List[str]:
+        return []
+
+
+# +---------------------------------------------------------------------------+
+# | LANGUAGE CLASSLOADER
+# +---------------------------------------------------------------------------+
+
+
+class LanguageClassLoader:
+    """
+    Class loader to resolve concrete :class:`nunavut.lang.Language` types.
+
+    :param additional_config_files: A list of paths to additional configuration files to load as configuration.
+        These will override any values found in the :file:`nunavut.lang.properties.yaml` file and files
+        appearing later in this list will override value found in earlier entries.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import LanguageClassLoader, LanguageConfig
+
+            subject = LanguageClassLoader()
+
+            c_reserved_identifiers = subject.config.get_config_value(
+                LanguageClassLoader.to_language_module_name("c"), "reserved_identifiers")
+            assert len(c_reserved_identifiers) > 0
+    """
+
+    MODULE_NAME = "nunavut.lang"
+    MODULE_PREFIX = MODULE_NAME + "."
+    MODULE_FORMAT = MODULE_PREFIX + "{}"
+
+    @classmethod
+    def to_language_name(cls, unknown_string: str) -> str:
+        """
+        Helper method to take a string that is either a language name or a language module name
+        and always return a langauge name.
+
+        .. invisible-code-block: python
+            from nunavut.lang import LanguageClassLoader
+
+        .. code-block: python
+
+            assert "c" == LanguageClassLoader.to_language_name("c")
+            assert "c" == LanguageClassLoader.to_language_name("nunavut.lang.c")
+
+        """
+        return (
+            unknown_string[len(cls.MODULE_PREFIX) :] if unknown_string.startswith(cls.MODULE_PREFIX) else unknown_string
+        )
+
+    @classmethod
+    def to_language_module_name(cls, unknown_string: str) -> str:
+        """
+        Helper method to take a string that is either a language name or a language module name
+        and always return a langauge module name.
+
+        .. invisible-code-block: python
+            from nunavut.lang import LanguageClassLoader
+
+        .. code-block: python
+
+            assert "nunavut.lang.c" == LanguageClassLoader.to_language_module_name("c")
+            assert "nunavut.lang.c" == LanguageClassLoader.to_language_module_name("nunavut.lang.c")
+
+        """
+        return (
+            cls.MODULE_FORMAT.format(unknown_string)
+            if not unknown_string.startswith(cls.MODULE_PREFIX)
+            else unknown_string
+        )
+
+    @classmethod
+    def _load_config(cls) -> LanguageConfig:
+        parser = LanguageConfig()
+        for resource in iter_package_resources(cls.MODULE_NAME, ".yaml"):
+            ini_string = resource.read_text()
+            parser.update_from_string(ini_string)
+        return parser
+
+    def __init__(self) -> None:
+        self._config = None  # type: typing.Optional[LanguageConfig]
+
+    @classmethod
+    def load_language_module(cls, language_name: str) -> "types.ModuleType":
+        module_name = cls.to_language_module_name(language_name)
+        return importlib.import_module(module_name)
+
+    @property
+    def config(self) -> LanguageConfig:
+        """
+        Meta-data about all languages merged from the Nunavut internal defaults and any additional
+        configuration files provided to this class's constructor.
+        """
+        if self._config is None:
+            self._config = self._load_config()
+        return self._config
+
+    @functools.lru_cache()
+    def load_language_class(self, language_name: str) -> typing.Tuple[types.ModuleType, typing.Type[Language]]:
+        """
+        :param str language_name:                The name of the language used by the :mod:`nunavut.lang` module.
+
+        :return: A concrete :class:`nunavut.lang.Language`.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import LanguageClassLoader, Language
+
+            lang_c_mod, lang_c_cls = LanguageClassLoader().load_language_class('c')
+            assert lang_c_mod.__name__ == 'nunavut.lang.c'
+            assert issubclass(lang_c_cls, Language)
+
+        """
+        ln_module = self.load_language_module(language_name)
+
+        try:
+            language_type = typing.cast(typing.Type["Language"], getattr(ln_module, "Language"))
+        except AttributeError:
+            logging.debug(
+                "Unable to find a Language object in nunavut.lang.{}. Using a Generic language object".format(
+                    language_name
+                )
+            )
+            language_type = _GenericLanguage
+
+        if language_type == Language:
+            # the language module just imported the base class so let's go ahead and use _GenericLanguage
+            language_type = _GenericLanguage
+
+        return (ln_module, language_type)
+
+    def new_language(self, language_name: str, **kwargs: typing.Any) -> Language:
+        """
+        Instantiate a new language class. This is a helper that reuses the internally held
+        module and :class:`LanguageConfig` to invoke the required :class:`nunavut.lang.Language` constructor.
+
+        :param str language_name:                The name of the language used by the :mod:`nunavut.lang` module.
+        :param kwargs:                           Opaque arguments passed to the :class:`nunavut.lang.Language`
+                                                 constructor.
+
+        :return: A new :class:`nunavut.lang.Language` instance.
+
+        .. invisible-code-block: python
+
+            from nunavut.lang import LanguageClassLoader
+
+        .. code-block:: python
+
+            # Using this helper method:
+
+            lang_c = LanguageClassLoader().new_language('c')
+
+            assert lang_c.name == 'c'
+
+
+            # Without the helper:
+
+            loader = LanguageClassLoader()
+            lang_c_module, lang_c_class = loader.load_language_class('c')
+            lang_c = lang_c_class(lang_c_module.__name__, loader.config)
+
+            assert lang_c.name == 'c'
+
+        .. invisible-code-block: python
+
+            # let's go ahead and load the rest of our known, internally supported languages just to raise
+            # test failures right here at the wellspring.
+
+            lang_py = LanguageClassLoader().new_language('py')
+            assert lang_py.name == 'py'
+
+            lang_js = LanguageClassLoader().new_language('js')
+            assert lang_js.name == 'js'
+
+        """
+        ln_module, ln_class = self.load_language_class(language_name)
+        return ln_class(ln_module.__name__, config=self.config, **kwargs)

--- a/src/nunavut/lang/c/__init__.py
+++ b/src/nunavut/lang/c/__init__.py
@@ -23,10 +23,12 @@ from ...templates import (
     template_language_list_filter,
     template_language_test,
     template_volatile_filter,
+    template_environment_list_filter,
 )
-from .. import Dependencies
+from ...dependencies import Dependencies
 from .. import Language as BaseLanguage
 from .._common import IncludeGenerator, TokenEncoder, UniqueNameGenerator
+from ...jinja.environment import Environment
 
 
 class Language(BaseLanguage):
@@ -173,7 +175,7 @@ def filter_macrofy(language: Language, value: str) -> str:
 
     .. invisible-code-block: python
 
-        from nunavut.lang import LanguageContext, Language
+        from nunavut.lang import Language, LanguageContextBuilder
         from nunavut.lang.c import filter_macrofy, filter_id
         from unittest.mock import MagicMock
 
@@ -237,8 +239,12 @@ def filter_macrofy(language: Language, value: str) -> str:
 
     .. invisible-code-block: python
 
-        config_overrides = {'nunavut.lang.c': {'enable_stropping': False }}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, False)
+                .create()
+        )
         jinja_filter_tester(filter_macrofy, template, rendered, lctx)
 
     :param str value: The value to transform.
@@ -298,7 +304,7 @@ class _CFit(enum.Enum):
         elif isinstance(value, pydsdl.FloatType):
             return self.to_c_float()
         elif isinstance(value, pydsdl.BooleanType):
-            return language.get_named_types()["boolean"]
+            return language.named_types["boolean"]
         elif isinstance(value, pydsdl.VoidType):
             return "void"
         else:
@@ -612,8 +618,12 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
 
     .. invisible-code-block: python
 
-        config_overrides = {'nunavut.lang.c': {'enable_stropping': False }}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, False)
+                .create()
+        )
         jinja_filter_tester(filter_short_reference_name, template, rendered, lctx, my_type=my_type)
 
     :param pydsdl.CompositeType t: The DSDL type to get the reference name for.
@@ -622,7 +632,10 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
 
 
 @template_language_list_filter(__name__)
-def filter_includes(language: Language, t: pydsdl.CompositeType, sort: bool = True) -> typing.List[str]:
+@template_environment_list_filter
+def filter_includes(
+    language: Language, env: Environment, t: pydsdl.CompositeType, sort: bool = True
+) -> typing.List[str]:
     """
     Returns a list of all include paths for a given type.
 
@@ -661,16 +674,25 @@ def filter_includes(language: Language, t: pydsdl.CompositeType, sort: bool = Tr
 
     .. invisible-code-block: python
 
-        config_overrides = {'nunavut.lang.c': {'use_standard_types': False}}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override("use_standard_types", False)
+                .create()
+        )
         jinja_filter_tester(filter_includes, template, rendered, lctx, my_type=my_type)
 
     :param pydsdl.CompositeType t: The type to scan for dependencies.
     :param bool sort: If true the returned list will be sorted.
     :return: a list of include headers needed for a given type.
     """
-
-    return IncludeGenerator(language, t).generate_include_filepart_list(language.extension, sort)
+    try:
+        omit_serialization_support = env.globals["nunavut"].support["omit"]
+    except KeyError:
+        omit_serialization_support = False
+    return IncludeGenerator(language, t, omit_serialization_support).generate_include_filepart_list(
+        language.extension, sort
+    )
 
 
 def filter_to_static_assertion_value(obj: typing.Any) -> int:
@@ -791,8 +813,13 @@ def filter_constant_value(language: Language, constant: pydsdl.Constant) -> str:
 
     .. invisible-code-block: python
 
-        config_overrides = {'nunavut.lang.c': {'named_values': {'true': 'NUNAVUT_TRUE'}}}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+        named_values = {'true': 'NUNAVUT_TRUE'}
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_NAMED_VALUES, named_values)
+                .create()
+        )
         jinja_filter_tester(filter_constant_value, template, rendered, lctx, my_true_constant=my_true_constant)
 
 
@@ -990,8 +1017,14 @@ def is_zero_cost_primitive(language: Language, t: pydsdl.PrimitiveType) -> bool:
         rendered = 'False True False True False'
 
     .. invisible-code-block: python
-        config_overrides = {'nunavut.lang.c': {'options': {'target_endianness': 'little' }}}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+
+        options = {'target_endianness': 'little'}
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                .create()
+        )
         jinja_filter_tester(is_zero_cost_primitive, template, rendered, lctx, i7=i7, u32=u32, f16=f16, f32=f32, bl=bl)
 
         # ensure unknown types given to test raise a TypeError
@@ -1002,8 +1035,13 @@ def is_zero_cost_primitive(language: Language, t: pydsdl.PrimitiveType) -> bool:
             pass
 
         # big endian is never zero cost.
-        config_overrides = {'nunavut.lang.c': {'options': {'target_endianness': 'big'}}}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+        options = {'target_endianness': 'big'}
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                .create()
+        )
         jinja_filter_tester(is_zero_cost_primitive,
                             template,
                             'False False False False False',
@@ -1051,8 +1089,13 @@ def filter_is_zero_cost_primitive(language: Language, t: pydsdl.PrimitiveType) -
 
     .. invisible-code-block: python
 
-        config_overrides = {'nunavut.lang.c': {'options': {'target_endianness': 'little' }}}
-        lctx = configurable_language_context_factory(config_overrides, 'c')
+        options = {'target_endianness': 'little'}
+        lctx = (
+            LanguageContextBuilder()
+                .set_target_language("c")
+                .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                .create()
+        )
 
         jinja_filter_tester(filter_is_zero_cost_primitive, deprecated_template, 'True', lctx, u32=u32)
         jinja_filter_tester(is_zero_cost_primitive, correct_template, 'True', lctx, u32=u32)

--- a/src/nunavut/lang/cpp/__init__.py
+++ b/src/nunavut/lang/cpp/__init__.py
@@ -19,12 +19,18 @@ import typing
 import pydsdl
 
 from ..._utilities import YesNoDefault, ResourceType
-from ...templates import template_language_filter, template_language_list_filter, template_language_test
-from .. import Dependencies
+from ...templates import (
+    template_language_filter,
+    template_language_list_filter,
+    template_language_test,
+    template_environment_list_filter,
+)
+from ...dependencies import Dependencies
 from .. import Language as BaseLanguage
 from .._common import IncludeGenerator, TokenEncoder, UniqueNameGenerator
 from ..c import _CFit
 from ..c import filter_literal as c_filter_literal
+from ...jinja.environment import Environment
 
 
 class Language(BaseLanguage):
@@ -70,18 +76,32 @@ class Language(BaseLanguage):
         """
         .. invisible-code-block: python
 
-           from nunavut.lang import LanguageLoader
+           from nunavut.lang import LanguageContextBuilder
 
            # test c++17
-           language = LanguageLoader().load_language('cpp', True, {'std': 'c++17'})
+           language = LanguageContextBuilder(include_experimental_languages=True)\
+               .set_target_language("cpp")\
+               .set_target_language_configuration_override("options", { "std":"c++17"})\
+               .create()\
+               .get_target_language()
+
            assert language._standard_version() == 17
 
            # test c++14
-           language = LanguageLoader().load_language('cpp', True, {'std': 'c++14'})
+           language = LanguageContextBuilder(include_experimental_languages=True)\
+               .set_target_language("cpp")\
+               .set_target_language_configuration_override("options", { "std":"c++14"})\
+               .create()\
+               .get_target_language()
            assert language._standard_version() == 14
 
            # test gnu++20
-           language = LanguageLoader().load_language('cpp', True, {'std': 'gnu++20'})
+           language = LanguageContextBuilder(include_experimental_languages=True)\
+               .set_target_language("cpp")\
+               .set_target_language_configuration_override("options", { "std":"gnu++20"})\
+               .create()\
+               .get_target_language()
+
            assert language._standard_version() == 20
         """
         std = str(self.get_option("std", ""))
@@ -97,18 +117,33 @@ class Language(BaseLanguage):
         """
         .. invisible-code-block: python
 
-           from nunavut.lang import LanguageLoader
+           from nunavut.lang import LanguageClassLoader
 
            # test c++17
-           language = LanguageLoader().load_language('cpp', True, {'std': 'c++17'})
+           language = LanguageContextBuilder(include_experimental_languages=True)\
+               .set_target_language("cpp")\
+               .set_target_language_configuration_override("options", { "std":"c++17"})\
+               .create()\
+               .get_target_language()
+
            assert language._has_variant()
 
            # test c++14
-           language = LanguageLoader().load_language('cpp', True, {'std': 'c++14'})
+           language = LanguageContextBuilder(include_experimental_languages=True)\
+               .set_target_language("cpp")\
+               .set_target_language_configuration_override("options", { "std":"c++14"})\
+               .create()\
+               .get_target_language()
+
            assert not language._has_variant()
 
            # test gnu++20
-           language = LanguageLoader().load_language('cpp', True, {'std': 'gnu++20'})
+           language = LanguageContextBuilder(include_experimental_languages=True)\
+               .set_target_language("cpp")\
+               .set_target_language_configuration_override("options", { "std":"gnu++20"})\
+               .create()\
+               .get_target_language()
+
            assert language._has_variant()
         """
         return self._standard_version() >= 17
@@ -131,25 +166,24 @@ class Language(BaseLanguage):
         Returns a template to the built-in Variable Length Array (VLA) implementation. This is used when no override
         was provided.
 
-        config_no_namespace = {
-                    'nunavut.lang.cpp':
-                    {
-                        'support_namesapce': ''
-                    }
-                }
-
-        lctx = configurable_language_context_factory(config_no_namespace, 'cpp')
+        options = {"target_endianness": "big"}
+        lctx = (
+            LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language("cpp")
+                .set_target_language_configuration_override(Language.WKCV_SUPPORT_NAMESPACE, "")
+                .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                .create()
+        )
         template_w_no_namespace = lctx.get_target_language()._get_default_vla_template()
         assert template_w_no_namespace.startswith("VariableLengthArray")
 
-        config_w_namespace = {
-                    'nunavut.lang.cpp':
-                    {
-                        'support_namesapce': 'foo.bar'
-                    }
-                }
-
-        lctx = configurable_language_context_factory(config_w_namespace, 'cpp')
+        lctx = (
+            LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language("cpp")
+                .set_target_language_configuration_override(Language.WKCV_SUPPORT_NAMESPACE, "foo.bar")
+                .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                .create()
+        )
         template_w_namespace = lctx.get_target_language()._get_default_vla_template()
         assert template_w_namespace.startswith("foo::bar::VariableLengthArray")
 
@@ -175,16 +209,14 @@ class Language(BaseLanguage):
                 foobar_header_name = "foobar.h"
                 include_value = '' if not use_foobar else foobar_header_name
 
-                config = {
-                    'nunavut.lang.cpp':
-                    {
-                        'variable_array_type_include': include_value,
-                        'extension': extension
-                    }
-                }
-
-                lctx = configurable_language_context_factory(config, 'cpp')
-                lang_cpp = lctx.get_target_language()
+                lang_cpp = (
+                    LanguageContextBuilder(include_experimental_languages=True)
+                        .set_target_language("cpp")
+                        .set_target_language_configuration_override("variable_array_type_include", include_value)
+                        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, extension)
+                        .create()
+                        .get_target_language()
+                )
                 assert extension == lang_cpp.extension
 
                 test_dependencies = Dependencies()
@@ -281,13 +313,23 @@ def uses_std_variant(language: Language) -> bool:
         .. invisible-code-block: python
 
             # test c++17
-            config_overrides = {'nunavut.lang.cpp': {'options': {'std': 'c++17' }}}
-            lctx = configurable_language_context_factory(config_overrides, 'cpp')
+            options = {"std": "c++17"}
+            lctx = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                    .set_target_language("cpp")
+                    .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                    .create()
+            )
             jinja_filter_tester(None, template, '#include <variant>', lctx)
 
             # test c++14
-            config_overrides = {'nunavut.lang.cpp': {'options': {'std': 'c++14' }}}
-            lctx = configurable_language_context_factory(config_overrides, 'cpp')
+            options = {"std": "c++14"}
+            lctx = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                    .set_target_language("cpp")
+                    .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+                    .create()
+            )
             jinja_filter_tester(None, template, '#include "user_variant.h"', lctx)
 
     """
@@ -507,10 +549,20 @@ def filter_open_namespace(
 
         # stropping doesn't change our example here.
 
-        lctx = configurable_language_context_factory({'nunavut.lang.cpp': {'enable_stropping': False}}, 'cpp')
+        lctx = (
+            LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language("cpp")
+                .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, False)
+                .create()
+        )
         jinja_filter_tester(filter_open_namespace, template, rendered, lctx, T=T)
 
-        lctx = configurable_language_context_factory({'nunavut.lang.cpp': {'enable_stropping': True}}, 'cpp')
+        lctx = (
+            LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language("cpp")
+                .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, True)
+                .create()
+        )
         jinja_filter_tester(filter_open_namespace, template, rendered, lctx, T=T)
 
     :param str full_namespace: A dot-separated namespace string.
@@ -801,15 +853,63 @@ def filter_short_reference_name(language: Language, t: pydsdl.CompositeType) -> 
 
 
 @template_language_list_filter(__name__)
-def filter_includes(language: Language, t: pydsdl.CompositeType, sort: bool = True) -> typing.List[str]:
+@template_environment_list_filter
+def filter_includes(
+    language: Language, env: Environment, t: pydsdl.CompositeType, sort: bool = True
+) -> typing.List[str]:
     """
     Returns a list of all include paths for a given type.
 
     :param pydsdl.CompositeType t: The type to scan for dependencies.
     :param bool sort: If true the returned list will be sorted.
     :return: a list of include headers needed for a given type.
+
+
+    .. invisible-code-block: python
+
+        from nunavut.lang.cpp import filter_includes
+        from unittest.mock import MagicMock
+        import pydsdl
+
+        my_type = MagicMock(spec=pydsdl.UnionType)
+        my_type.version = MagicMock()
+        my_type.parent_service = None
+
+    .. code-block:: python
+
+        # Listing the includes for a union with only integer types:
+        template = "{% for include in my_type | includes -%}{{include}}{%- endfor %}"
+
+        # stdint.h will normally be generated
+        rendered = "<cstdint>"
+
+    .. invisible-code-block: python
+
+        jinja_filter_tester(filter_includes, template, rendered, "cpp", my_type=my_type)
+
+    .. code-block:: python
+
+        # You can suppress std includes by setting use_standard_types to False under
+        # nunavut.lang.cpp
+        rendered = ""
+
+    .. invisible-code-block: python
+
+        lctx = (
+            LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language("cpp")
+                .set_target_language_configuration_override("use_standard_types", False)
+                .create()
+        )
+        jinja_filter_tester(filter_includes, template, rendered, lctx, my_type=my_type)
     """
-    return IncludeGenerator(language, t).generate_include_filepart_list(language.extension, sort)
+    try:
+        omit_serialization_support = env.globals["nunavut"].support["omit"]
+    except KeyError:
+        omit_serialization_support = False
+    return IncludeGenerator(language, t, omit_serialization_support).generate_include_filepart_list(
+        language.extension, sort
+    )
 
 
 @template_language_filter(__name__)
@@ -1090,7 +1190,12 @@ def filter_type_from_primitive(language: Language, value: pydsdl.PrimitiveType) 
 
     .. invisible-code-block: python
 
-        lctx = configurable_language_context_factory({'nunavut.lang.cpp': {'use_standard_types': False}}, 'cpp')
+        lctx = (
+            LanguageContextBuilder(include_experimental_languages=True)
+                .set_target_language("cpp")
+                .set_target_language_configuration_override("use_standard_types", False)
+                .create()
+        )
         jinja_filter_tester(filter_type_from_primitive,
                             template,
                             rendered,
@@ -1613,10 +1718,15 @@ def filter_block_comment(language: Language, text: str, style: str, indent: int 
 
             jinja_filter_tester(filter_block_comment, template, rendered, 'cpp', text=text)
 
-            from nunavut.lang import LanguageContext
+            from nunavut.lang import LanguageContextBuilder
 
-            comment_configs = LanguageContext('cpp').get_target_language().get_config_value_as_dict('comment_styles')
-
+            comment_configs = (
+                LanguageContextBuilder(include_experimental_languages=True)
+                    .set_target_language('cpp')
+                    .create()
+                    .get_target_language()
+                    .get_config_value_as_dict('comment_styles')
+            )
             if len(comment_configs) != 5:
                 raise RuntimeError('A comment style was added but not documented here. Please document it/them.')
 

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -77,6 +77,11 @@ static_assert(sizeof({{ typename_unsigned_bit_length }}) >= sizeof({{ typename_u
 
 namespace nunavut
 {
+    {%- if options.std == "c++11" %}
+    // std::max is not constexpr until C++14, this function will fix errors in a C++11 compiler.
+    template <typename T>
+    constexpr T max(T x, T y) {return (x < y) ? y : x;}
+    {%- endif %}
 namespace support
 {
 
@@ -138,9 +143,15 @@ struct unexpected final{
 template<typename Ret>
 class expected final{
     // We can use a maximum of all types.
+    {% if options.std == "c++11" -%}
     using storage_t = typename std::aligned_storage<
-        (std::max(sizeof(Ret), sizeof(Error))),
-        (std::max(alignof(Ret), alignof(Error)))>::type;
+        (nunavut::max(sizeof(Ret), sizeof(Error))),
+        (nunavut::max(alignof(Ret), alignof(Error)))>::type;
+    {%- else -%}
+    using storage_t = typename std::aligned_storage<
+         (std::max(sizeof(Ret), sizeof(Error))),
+         (std::max(alignof(Ret), alignof(Error)))>::type;
+    {%- endif %}
     storage_t storage;
     bool is_expected_;
 private:

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -19,6 +19,10 @@
 #    include <stdexcept>
 #endif
 
+static_assert(
+    __cplusplus >= 201402L,
+    "Unsupported language: ISO C14, C++14, or a newer version of either is required to use the built-in VLA type");
+
 namespace nunavut
 {
 namespace support
@@ -670,7 +674,6 @@ private:
         // opportunity for reusing previously freed memory comes when increasing to 19 from 13 since E(n-1) == 21.
         const std::size_t new_capacity = capacity_before + ((half_capacity <= 1) ? 2 : half_capacity);
 
-
         if (new_capacity > MaxSize)
         {
             reserve(MaxSize);
@@ -691,7 +694,6 @@ private:
         {
             return true;
         }
-
     }
 
     template <typename U>

--- a/src/nunavut/lang/py/__init__.py
+++ b/src/nunavut/lang/py/__init__.py
@@ -21,7 +21,7 @@ from ...templates import (
     template_language_int_filter,
     template_language_list_filter,
 )
-from .. import Dependencies
+from ...dependencies import Dependencies
 from .. import Language as BaseLanguage
 from .._common import TokenEncoder, UniqueNameGenerator
 

--- a/src/nunavut/postprocessors.py
+++ b/src/nunavut/postprocessors.py
@@ -101,7 +101,7 @@ class LinePostProcessor(PostProcessor):
         ...
 
         c_style = CommentItAllOut('/*', '*/')
-        my_generator.generate_all(False, True, [c_style])
+        my_generator.generate_all(False, True, True, [c_style])
     """
 
     @abc.abstractmethod

--- a/src/nunavut/templates.py
+++ b/src/nunavut/templates.py
@@ -42,7 +42,7 @@ class SupportsTemplateContext:
     """
 
 
-def template_environment_filter(filter_func: typing.Callable) -> typing.Callable[..., str]:
+def template_environment_list_filter(filter_func: typing.Callable) -> typing.Callable[..., typing.List[str]]:
     """
     Decorator for marking environment dependent filters.
     An object supporting the :class:`SupportsTemplateEnv` protocol
@@ -140,7 +140,7 @@ class template_language_test(GenericTemplateLanguageFilter[bool]):
 
 class LanguageEnvironment:
     """
-    Data structure defining stuff contributed to a template environment for a given :class:`Language`.
+    Data structure defining stuff contributed to a template environment for a given :class:`nunavut.lang.Language`.
     """
 
     TEST_NAME_PREFIX = "is_"
@@ -249,6 +249,18 @@ class LanguageEnvironment:
                 for language in supported_languages:
                     if language.get_templates_package_name() == callable_language_name:
                         resolved_callable = functools.partial(callable, language)
+                        if hasattr(callable, ENVIRONMENT_FILTER_ATTRIBUTE_NAME):
+                            setattr(
+                                resolved_callable,
+                                ENVIRONMENT_FILTER_ATTRIBUTE_NAME,
+                                getattr(callable, ENVIRONMENT_FILTER_ATTRIBUTE_NAME),
+                            )
+                        if hasattr(callable, CONTEXT_FILTER_ATTRIBUTE_NAME):
+                            setattr(
+                                resolved_callable,
+                                CONTEXT_FILTER_ATTRIBUTE_NAME,
+                                getattr(callable, CONTEXT_FILTER_ATTRIBUTE_NAME),
+                            )
                         break
             if resolved_callable is None:
                 raise RuntimeWarning(

--- a/src/nunavut/version.py
+++ b/src/nunavut/version.py
@@ -7,7 +7,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "1.9.0"  #: The version number used in the release of nunavut to pypi.
+__version__ = "2.0.0"  #: The version number used in the release of nunavut to pypi.
 
 
 __license__ = "MIT"

--- a/test/gentest_any/test_any.py
+++ b/test/gentest_any/test_any.py
@@ -9,31 +9,30 @@ from pathlib import Path
 from pydsdl import read_namespace
 from nunavut import build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder
 
 import pytest
 
 
-@pytest.mark.parametrize('lang_key', [('cpp')])
+@pytest.mark.parametrize("lang_key", [("cpp")])
 def test_anygen(gen_paths, lang_key):  # type: ignore
     """
     Verifies that any dsdl type will resolve to an ``Any`` template.
     """
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
     type_map = read_namespace(str(root_namespace_dir), [])
-    language_context = LanguageContext(extension='.json')
-    namespace = build_namespace_tree(type_map,
-                                     root_namespace_dir,
-                                     str(gen_paths.out_dir),
-                                     language_context)
+    language_context = (
+        LanguageContextBuilder().set_target_language_configuration_override("extension", ".json").create()
+    )
+    namespace = build_namespace_tree(type_map, root_namespace_dir, str(gen_paths.out_dir), language_context)
     generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.SynchronizedTimestamp", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None

--- a/test/gentest_arrays/test_arrays.py
+++ b/test/gentest_arrays/test_arrays.py
@@ -11,29 +11,27 @@ from pathlib import Path
 import pydsdl
 from nunavut import build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder, Language
 
 
-def assert_pattern_match_in_file(file: typing.Optional[Path], * patterns: 're.Pattern') -> None:
+def assert_pattern_match_in_file(file: typing.Optional[Path], *patterns: "re.Pattern") -> None:
     """
     Assert that a given pattern is found within a given file at least once. The pattern
     is matched for each line in the file (i.e. multi-line matches are not supported).
     """
-    assert (file is not None)
+    assert file is not None
     results = {}  # type: typing.Dict[re.Pattern, bool]
     for pattern in patterns:
         results[pattern] = False
 
-    with open(str(file), 'r') as file_handle:
+    with open(str(file), "r") as file_handle:
         for line in file_handle:
             for pattern in patterns:
                 if pattern.match(line):
                     results[pattern] = True
 
     for key, value in results.items():
-        assert value, 'pattern \"{}\" was not found in file \"{}\"'.format(
-            str(key),
-            str(file))
+        assert value, 'pattern "{}" was not found in file "{}"'.format(str(key), str(file))
 
 
 def test_default_array_type_cpp(gen_paths):  # type: ignore
@@ -42,17 +40,14 @@ def test_default_array_type_cpp(gen_paths):  # type: ignore
     """
     root_namespace = str(gen_paths.dsdl_dir / Path("radar"))
     compound_types = pydsdl.read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
-    language_context = LanguageContext('cpp')
-    namespace = build_namespace_tree(compound_types,
-                                     root_namespace,
-                                     gen_paths.out_dir,
-                                     language_context)
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("cpp").create()
+    namespace = build_namespace_tree(compound_types, root_namespace, gen_paths.out_dir, language_context)
     generator = DSDLCodeGenerator(namespace)
     generator.generate_all(False)
 
     assert_pattern_match_in_file(
         gen_paths.find_outfile_in_namespace("radar.Phased", namespace),
-        re.compile(r'\s*std::array<float,3>\s+bank_normal_rads;\s*')
+        re.compile(r"\s*std::array<float,3>\s+bank_normal_rads;\s*"),
     )
 
 
@@ -61,21 +56,22 @@ def test_var_array_override_cpp(gen_paths):  # type: ignore
     Make sure we can override the type generated for variable-length
     arrays.
     """
-    language_option_overrides = {'variable_array_type_template': 'scotec::TerribleArray<{TYPE},{MAX_SIZE}>'}
+    language_option_overrides = {"variable_array_type_template": "scotec::TerribleArray<{TYPE},{MAX_SIZE}>"}
     root_namespace = str(gen_paths.dsdl_dir / Path("radar"))
     compound_types = pydsdl.read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
-    language_context = LanguageContext('cpp',
-                                       language_options=language_option_overrides)
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("cpp")
+        .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, language_option_overrides)
+        .create()
+    )
 
-    namespace = build_namespace_tree(compound_types,
-                                     root_namespace,
-                                     gen_paths.out_dir,
-                                     language_context)
+    namespace = build_namespace_tree(compound_types, root_namespace, gen_paths.out_dir, language_context)
     generator = DSDLCodeGenerator(namespace)
     generator.generate_all(False)
 
     assert_pattern_match_in_file(
         gen_paths.find_outfile_in_namespace("radar.Phased", namespace),
-        re.compile(r'\s*scotec::TerribleArray<float,2677>\s+antennae_per_bank;\s*'),
-        re.compile(r'\s*std::array<float,3>\s+bank_normal_rads;\s*')
+        re.compile(r"\s*scotec::TerribleArray<float,2677>\s+antennae_per_bank;\s*"),
+        re.compile(r"\s*std::array<float,3>\s+bank_normal_rads;\s*"),
     )

--- a/test/gentest_dsdl/test_dsdl.py
+++ b/test/gentest_dsdl/test_dsdl.py
@@ -13,20 +13,20 @@ from nunavut import generate_types
 @pytest.mark.parametrize(
     "lang_key,generate_support,language_options",
     [
-        ("cpp", False, None),
-        ("cpp", True, None),
+        ("cpp", False, {}),
+        ("cpp", True, {}),
         ("cpp", True, {"std": "c++17"}),
-        ("c", False, None),
-        ("c", True, None),
-        ("py", False, None),
-        ("html", False, None),
+        ("c", False, {}),
+        ("c", True, {}),
+        ("py", False, {}),
+        ("html", False, {}),
     ],
 )
 def test_realgen(
     gen_paths: typing.Any,
     lang_key: str,
     generate_support: bool,
-    language_options: typing.Optional[typing.Mapping[str, typing.Any]],
+    language_options: typing.Mapping[str, typing.Any],
 ) -> None:
     """
     Sanity test that runs through the entire public, regulated set of
@@ -39,4 +39,5 @@ def test_realgen(
         gen_paths.out_dir,
         omit_serialization_support=not generate_support,
         language_options=language_options,
+        include_experimental_languages=True
     )

--- a/test/gentest_filters/test_filters.py
+++ b/test/gentest_filters/test_filters.py
@@ -13,7 +13,7 @@ import pytest
 from nunavut import Namespace, build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
 from nunavut.jinja.jinja2.exceptions import TemplateAssertionError
-from nunavut.lang import LanguageContext
+from nunavut.lang import Language, LanguageClassLoader, LanguageContextBuilder
 from pydsdl import read_namespace
 
 
@@ -22,14 +22,15 @@ def test_template_assert(gen_paths):  # type: ignore
     Tests our template assertion extension.
     """
     root_path = str(gen_paths.dsdl_dir / Path("uavcan"))
-    output_path = gen_paths.out_dir / 'assert'
+    output_path = gen_paths.out_dir / "assert"
     compound_types = read_namespace(root_path, [])
-    language_context = LanguageContext(extension='.json')
-    namespace = build_namespace_tree(compound_types,
-                                     root_path,
-                                     output_path,
-                                     language_context)
-    template_path = gen_paths.templates_dir / Path('assert')
+    language_context = (
+        LanguageContextBuilder()
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".json")
+        .create()
+    )
+    namespace = build_namespace_tree(compound_types, root_path, output_path, language_context)
+    template_path = gen_paths.templates_dir / Path("assert")
     generator = DSDLCodeGenerator(namespace, templates_dir=template_path)
     try:
         generator.generate_all()
@@ -37,167 +38,192 @@ def test_template_assert(gen_paths):  # type: ignore
     except TemplateAssertionError as e:
         e.filename == str(template_path / "Any.j2")
         e.filename == 2
-        e.message == 'Template assertion failed.'
+        e.message == "Template assertion failed."
 
 
 def test_type_to_include(gen_paths):  # type: ignore
     """Test the type_to_include filter."""
     root_path = (gen_paths.dsdl_dir / Path("uavcan")).as_posix()
-    output_path = gen_paths.out_dir / 'type_to_include'
+    output_path = gen_paths.out_dir / "type_to_include"
     compound_types = read_namespace(root_path, [])
-    language_context = LanguageContext(extension='.json')
-    namespace = build_namespace_tree(compound_types,
-                                     root_path,
-                                     output_path,
-                                     language_context)
-    template_path = gen_paths.templates_dir / Path('type_to_include')
+    language_context = (
+        LanguageContextBuilder()
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".json")
+        .create()
+    )
+    namespace = build_namespace_tree(compound_types, root_path, output_path, language_context)
+    template_path = gen_paths.templates_dir / Path("type_to_include")
     generator = DSDLCodeGenerator(namespace, templates_dir=template_path)
     generator.generate_all()
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.SynchronizedTimestamp", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['include'] == "uavcan/time/SynchronizedTimestamp_1_0.json"
+    assert json_blob["include"] == "uavcan/time/SynchronizedTimestamp_1_0.json"
 
 
 def test_custom_filter_and_test(gen_paths):  # type: ignore
     root_path = str(gen_paths.dsdl_dir / Path("uavcan"))
-    output_path = gen_paths.out_dir / 'filter_and_test'
+    output_path = gen_paths.out_dir / "filter_and_test"
     compound_types = read_namespace(root_path, [])
-    language_context = LanguageContext(extension='.json')
-    namespace = build_namespace_tree(compound_types,
-                                     root_path,
-                                     output_path,
-                                     language_context)
-    template_path = gen_paths.templates_dir / Path('custom_filter_and_test')
-    generator = DSDLCodeGenerator(namespace,
-                                  templates_dir=template_path,
-                                  additional_filters={'custom_filter': lambda T: 'hi mum'},
-                                  additional_tests={'custom_test': lambda T: True})
+    language_context = (
+        LanguageContextBuilder()
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".json")
+        .create()
+    )
+    namespace = build_namespace_tree(compound_types, root_path, output_path, language_context)
+    template_path = gen_paths.templates_dir / Path("custom_filter_and_test")
+    generator = DSDLCodeGenerator(
+        namespace,
+        templates_dir=template_path,
+        additional_filters={"custom_filter": lambda T: "hi mum"},
+        additional_tests={"custom_test": lambda T: True},
+    )
 
     generator.generate_all()
     outfile = gen_paths.find_outfile_in_namespace("uavcan.time.SynchronizedTimestamp", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['filter_result'] == 'hi mum'
-    assert json_blob['test_result'] == 'yes'
+    assert json_blob["filter_result"] == "hi mum"
+    assert json_blob["test_result"] == "yes"
 
 
 def test_custom_filter_and_test_redefinition(gen_paths):  # type: ignore
-    language_context = LanguageContext(extension='.json')
-    namespace = Namespace('', Path(), PurePath(), language_context)
+    language_context = (
+        LanguageContextBuilder()
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".json")
+        .create()
+    )
+    namespace = Namespace("", Path(), PurePath(), language_context)
 
     with pytest.raises(RuntimeError):
-        DSDLCodeGenerator(namespace,
-                          additional_filters={'type_to_include_path': lambda T: ''},
-                          additional_tests={'custom_test': lambda T: False})
+        DSDLCodeGenerator(
+            namespace,
+            additional_filters={"type_to_include_path": lambda T: ""},
+            additional_tests={"custom_test": lambda T: False},
+        )
 
     with pytest.raises(RuntimeError):
-        DSDLCodeGenerator(namespace,
-                          additional_filters={'custom_filter': lambda T: ''},
-                          additional_tests={'primitive': lambda T: False})
+        DSDLCodeGenerator(
+            namespace,
+            additional_filters={"custom_filter": lambda T: ""},
+            additional_tests={"primitive": lambda T: False},
+        )
 
 
 def test_python_filter_full_reference_name(gen_paths):  # type: ignore
-    lctx = LanguageContext()
-    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path('uavcan')), [])
+    lctx = LanguageContextBuilder().create()
+    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path("uavcan")), [])
 
     from nunavut.lang.py import filter_full_reference_name
 
-    test_subject = next(filter(lambda type: (type.short_name == 'SynchronizedTimestamp'), type_map))
+    test_subject = next(filter(lambda type: (type.short_name == "SynchronizedTimestamp"), type_map))
 
-    full_reference_name = filter_full_reference_name(lctx.get_language('nunavut.lang.py'), test_subject)
+    full_reference_name = filter_full_reference_name(lctx.get_language("nunavut.lang.py"), test_subject)
     assert "uavcan.time.SynchronizedTimestamp_1_0" == full_reference_name
 
 
 def test_python_filter_short_reference_name(gen_paths):  # type: ignore
-    lctx = LanguageContext()
+    lctx = LanguageContextBuilder().create()
 
-    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path('uavcan')), [])
+    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path("uavcan")), [])
 
     from nunavut.lang.py import filter_short_reference_name
 
-    test_subject = next(filter(lambda type: (type.short_name == 'SynchronizedTimestamp'), type_map))
-    full_reference_name = filter_short_reference_name(lctx.get_language('nunavut.lang.py'), test_subject)
+    test_subject = next(filter(lambda type: (type.short_name == "SynchronizedTimestamp"), type_map))
+    full_reference_name = filter_short_reference_name(lctx.get_language("nunavut.lang.py"), test_subject)
     assert "SynchronizedTimestamp_1_0" == full_reference_name
 
 
 def test_python_filter_imports(gen_paths):  # type: ignore
-    lctx = LanguageContext()
+    lctx = LanguageContextBuilder().create()
 
-    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path('uavcan')), [])
+    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path("uavcan")), [])
 
     from nunavut.lang.py import filter_imports
 
-    test_subject = next(filter(lambda type: (type.short_name == 'bar'), type_map))
-    imports = filter_imports(lctx.get_language('nunavut.lang.py'), test_subject)
+    test_subject = next(filter(lambda type: (type.short_name == "bar"), type_map))
+    imports = filter_imports(lctx.get_language("nunavut.lang.py"), test_subject)
     assert len(imports) == 1
-    assert 'uavcan.time' == imports[0]
+    assert "uavcan.time" == imports[0]
 
 
-@pytest.mark.parametrize('stropping,sort', [(True, False), (False, True)])
+@pytest.mark.parametrize("stropping,sort", [(True, False), (False, True)])
 def test_python_filter_imports_for_service_type(gen_paths, stropping, sort):  # type: ignore
-    lctx = LanguageContext()
-    lctx.config.set('nunavut.lang.py', 'enable_stropping', str(stropping))
-    assert stropping == lctx.config.get_config_value_as_bool('nunavut.lang.py', 'enable_stropping')
+    lctx = (
+        LanguageContextBuilder()
+        .set_target_language("py")
+        .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, stropping)
+        .create()
+    )
+    lctx.config.set("nunavut.lang.py", "enable_stropping", str(stropping))
+    assert stropping == lctx.config.get_config_value_as_bool("nunavut.lang.py", "enable_stropping")
 
-    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path('uavcan')), [])
+    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path("uavcan")), [])
 
     from nunavut.lang.py import filter_imports
 
-    test_subject = next(filter(lambda type: (type.short_name == 'bar_svc'), type_map))
-    imports = filter_imports(lctx.get_language('nunavut.lang.py'), test_subject, sort=sort)
+    test_subject = next(filter(lambda type: (type.short_name == "bar_svc"), type_map))
+    imports = filter_imports(lctx.get_language("nunavut.lang.py"), test_subject, sort=sort)
     assert len(imports) == 2
     if stropping:
-        assert 'uavcan.str_' == imports[0]
+        assert "uavcan.str_" == imports[0]
     else:
-        assert 'uavcan.str' == imports[0]
-    assert 'uavcan.time' == imports[1]
+        assert "uavcan.str" == imports[0]
+    assert "uavcan.time" == imports[1]
 
 
-@pytest.mark.parametrize('stropping,sort', [(True, False), (False, True)])
+@pytest.mark.parametrize("stropping,sort", [(True, False), (False, True)])
 def test_python_filter_imports_for_array_type(gen_paths, stropping, sort):  # type: ignore
-    lctx = LanguageContext()
-    lctx.config.set('nunavut.lang.py', 'enable_stropping', str(stropping))
-
-    uavcan_dir = str(gen_paths.dsdl_dir / pathlib.Path('uavcan'))
-    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path('new')), [uavcan_dir])
+    lctx = (
+        LanguageContextBuilder()
+        .set_target_language("py")
+        .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, stropping)
+        .create()
+    )
+    uavcan_dir = str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))
+    type_map = read_namespace(str(gen_paths.dsdl_dir / pathlib.Path("new")), [uavcan_dir])
 
     assert len(type_map) == 2
 
     from nunavut.lang.py import filter_imports
 
-    test_subject = next(filter(lambda type: (type.short_name == 'hotness'), type_map))
-    imports = filter_imports(lctx.get_language('nunavut.lang.py'), test_subject, sort=sort)
+    test_subject = next(filter(lambda type: (type.short_name == "hotness"), type_map))
+    imports = filter_imports(lctx.get_language("nunavut.lang.py"), test_subject, sort=sort)
     assert len(imports) == 3
-    assert 'new' == imports[0]
+    assert "new" == imports[0]
     if stropping:
-        assert 'uavcan.str_' == imports[1]
+        assert "uavcan.str_" == imports[1]
     else:
-        assert 'uavcan.str' == imports[1]
-    assert 'uavcan.time' == imports[2]
+        assert "uavcan.str" == imports[1]
+    assert "uavcan.time" == imports[2]
 
 
-@pytest.mark.parametrize('stropping,sort', [(True, False), (False, True)])
-def test_python_filter_includes(gen_paths, stropping, sort):  # type: ignore
-    lctx = LanguageContext(target_language='cpp', extension='.h')
-    lctx.config.set('nunavut.lang.cpp', 'enable_stropping', str(stropping))
+@pytest.mark.parametrize("stropping,sort", [(True, False), (False, True)])
+def test_cpp_filter_includes(gen_paths, stropping, sort, mock_environment):  # type: ignore
+    lctx = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("cpp")
+        .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, stropping)
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".h")
+        .create()
+    )
 
-    uavcan_dir = (gen_paths.dsdl_dir / pathlib.Path('uavcan')).as_posix()
-    type_map = read_namespace((gen_paths.dsdl_dir / pathlib.Path('new')).as_posix(), [uavcan_dir])
+    uavcan_dir = (gen_paths.dsdl_dir / pathlib.Path("uavcan")).as_posix()
+    type_map = read_namespace((gen_paths.dsdl_dir / pathlib.Path("new")).as_posix(), [uavcan_dir])
     from nunavut.lang.cpp import filter_includes
 
-    test_subject = next(filter(lambda type: (type.short_name == 'hotness'), type_map))
-    imports = filter_includes(lctx.get_language('nunavut.lang.cpp'), test_subject, sort=sort)
+    test_subject = next(filter(lambda type: (type.short_name == "hotness"), type_map))
+    imports = filter_includes(lctx.get_target_language(), mock_environment, test_subject, sort=sort)
     assert len(imports) == 5
 
     def assert_path_in_imports(path: str) -> None:
@@ -206,92 +232,111 @@ def test_python_filter_includes(gen_paths, stropping, sort):  # type: ignore
 
     if stropping:
         if sort:
-            assert ['"_new/malloc_1_0.h"',
-                    '"uavcan/str/bar_1_0.h"',
-                    '"uavcan/time/SynchronizedTimestamp_1_0.h"',
-                    '<array>',
-                    '<cstdint>'
-                    ] == imports
-        else:
-
-            map(assert_path_in_imports, ('"uavcan/time/SynchronizedTimestamp_1_0.h"',
-                                         '"_new/malloc_1_0.h"',
-                                         '"uavcan/str/bar_1_0.h"',
-                                         '<array>',
-                                         '<cstdint>'))
-    elif sort:
-        assert ['"new/malloc_1_0.h"',
+            assert [
+                '"_new/malloc_1_0.h"',
                 '"uavcan/str/bar_1_0.h"',
                 '"uavcan/time/SynchronizedTimestamp_1_0.h"',
-                '<array>',
-                '<cstdint>'
-                ] == imports
+                "<array>",
+                "<cstdint>",
+            ] == imports
+        else:
+
+            map(
+                assert_path_in_imports,
+                (
+                    '"uavcan/time/SynchronizedTimestamp_1_0.h"',
+                    '"_new/malloc_1_0.h"',
+                    '"uavcan/str/bar_1_0.h"',
+                    "<array>",
+                    "<cstdint>",
+                ),
+            )
+    elif sort:
+        assert [
+            '"new/malloc_1_0.h"',
+            '"uavcan/str/bar_1_0.h"',
+            '"uavcan/time/SynchronizedTimestamp_1_0.h"',
+            "<array>",
+            "<cstdint>",
+        ] == imports
     else:
-        map(assert_path_in_imports, ('"uavcan/time/SynchronizedTimestamp_1_0.h"',
-                                     '"new/malloc_1_0.h"',
-                                     '"uavcan/str/bar_1_0.h"',
-                                     '<array>',
-                                     '<cstdint>'))
+        map(
+            assert_path_in_imports,
+            (
+                '"uavcan/time/SynchronizedTimestamp_1_0.h"',
+                '"new/malloc_1_0.h"',
+                '"uavcan/str/bar_1_0.h"',
+                "<array>",
+                "<cstdint>",
+            ),
+        )
 
 
-def test_filter_includes_cpp_vla(gen_paths):  # type: ignore
-    lctx = LanguageContext(target_language='cpp', extension='.h')
-    type_map = read_namespace((gen_paths.dsdl_dir / pathlib.Path('vla')).as_posix())
+def test_filter_includes_cpp_vla(gen_paths, mock_environment):  # type: ignore
+    lctx = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("cpp")
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".h")
+        .create()
+    )
+    type_map = read_namespace((gen_paths.dsdl_dir / pathlib.Path("vla")).as_posix())
     from nunavut.lang.cpp import filter_includes
 
-    test_subject = next(filter(lambda type: (type.short_name == 'uses_vla'), type_map))
-    imports = filter_includes(lctx.get_language('nunavut.lang.cpp'), test_subject)
+    test_subject = next(filter(lambda type: (type.short_name == "uses_vla"), type_map))
+    imports = filter_includes(lctx.get_target_language(), mock_environment, test_subject)
     assert '"nunavut/support/variable_length_array.h"' in imports
 
 
 @typing.no_type_check
-@pytest.mark.parametrize('language_name,namespace_separator', [('c', '_'), ('cpp', '::')])
+@pytest.mark.parametrize("language_name,namespace_separator", [("c", "_"), ("cpp", "::")])
 def test_filter_full_reference_name_via_template(gen_paths, language_name, namespace_separator):
     root_path = (gen_paths.dsdl_dir / Path("uavcan")).as_posix()
     output_path = (gen_paths.out_dir / Path("filter_and_test")).as_posix()
     compound_types = read_namespace(root_path, [])
-    language_context = LanguageContext(target_language=language_name)
-    namespace = build_namespace_tree(compound_types,
-                                     root_path,
-                                     output_path,
-                                     language_context)
-    template_path = gen_paths.templates_dir / Path('full_reference_test')
-    generator = DSDLCodeGenerator(namespace,
-                                  templates_dir=template_path)
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True).set_target_language(language_name).create()
+    )
+    namespace = build_namespace_tree(compound_types, root_path, output_path, language_context)
+    template_path = gen_paths.templates_dir / Path("full_reference_test")
+    generator = DSDLCodeGenerator(namespace, templates_dir=template_path)
 
     generator.generate_all()
     outfile = gen_paths.find_outfile_in_namespace("uavcan.str.bar_svc", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['parent']['full_reference_name'] == 'uavcan.str.bar_svc_1_0'.replace('.', namespace_separator)
-    assert json_blob['parent']['short_reference_name'] == 'bar_svc' if language_name == 'cpp' else 'bar_svc_1_0'
-    assert json_blob['request']['full_reference_name'] == 'uavcan.str.bar_svc.Request_1_0'.replace(
-        '.', namespace_separator)
-    assert json_blob['request']['short_reference_name'] == 'Request_1_0'
-    assert json_blob['response']['full_reference_name'] == 'uavcan.str.bar_svc.Response_1_0'.replace(
-        '.', namespace_separator)
-    assert json_blob['response']['short_reference_name'] == 'Response_1_0'
+    assert json_blob["parent"]["full_reference_name"] == "uavcan.str.bar_svc_1_0".replace(".", namespace_separator)
+    assert json_blob["parent"]["short_reference_name"] == "bar_svc" if language_name == "cpp" else "bar_svc_1_0"
+    assert json_blob["request"]["full_reference_name"] == "uavcan.str.bar_svc.Request_1_0".replace(
+        ".", namespace_separator
+    )
+    assert json_blob["request"]["short_reference_name"] == "Request_1_0"
+    assert json_blob["response"]["full_reference_name"] == "uavcan.str.bar_svc.Response_1_0".replace(
+        ".", namespace_separator
+    )
+    assert json_blob["response"]["short_reference_name"] == "Response_1_0"
 
 
 @typing.no_type_check
 @pytest.mark.parametrize(
-    'language_name,stropping,namespace_separator',
-    [('c', False, '_'),
-     ('c', True, '_'),
-     ('cpp', False, '::'),
-     ('cpp', True, '::')])
+    "language_name,stropping,namespace_separator",
+    [("c", False, "_"), ("c", True, "_"), ("cpp", False, "::"), ("cpp", True, "::")],
+)
 def test_filter_full_reference_name(gen_paths, language_name, stropping, namespace_separator):
     """
     Cover issue #153
     """
-    lctx = LanguageContext()
-    ln_package_name = 'nunavut.lang.{}'.format(language_name)
-    lctx.config.set(ln_package_name, 'enable_stropping', str(stropping))
+    lctx = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language(language_name)
+        .set_target_language_configuration_override(Language.WKCV_ENABLE_STROPPING, stropping)
+        .create()
+    )
+    ln_package_name = LanguageClassLoader.to_language_module_name(language_name)
     ln = lctx.get_language(ln_package_name)
 
     import importlib
@@ -300,37 +345,40 @@ def test_filter_full_reference_name(gen_paths, language_name, stropping, namespa
 
     test_subject_module = importlib.import_module(ln_package_name)
 
-    service_request_type = StructureType(name='register.getting.tired.of.Python',
-                                         version=Version(0, 1),
-                                         attributes=[],
-                                         deprecated=False,
-                                         fixed_port_id=None,
-                                         source_file_path=Path(),
-                                         has_parent_service=True)
-    service_response_type = StructureType(name='register.getting.tired.of.Python',
-                                          version=Version(0, 1),
-                                          attributes=[],
-                                          deprecated=False,
-                                          fixed_port_id=None,
-                                          source_file_path=Path(),
-                                          has_parent_service=True)
+    service_request_type = StructureType(
+        name="register.getting.tired.of.Python",
+        version=Version(0, 1),
+        attributes=[],
+        deprecated=False,
+        fixed_port_id=None,
+        source_file_path=Path(),
+        has_parent_service=True,
+    )
+    service_response_type = StructureType(
+        name="register.getting.tired.of.Python",
+        version=Version(0, 1),
+        attributes=[],
+        deprecated=False,
+        fixed_port_id=None,
+        source_file_path=Path(),
+        has_parent_service=True,
+    )
 
-    service_type = ServiceType(service_request_type,
-                               service_response_type,
-                               None)
+    service_type = ServiceType(service_request_type, service_response_type, None)
 
     # C++ is special because namespaces are part of the language and therefore each namespace
     # name must be stropped
-    top_level_name = ('_register' if stropping and language_name == 'cpp' else 'register')
+    top_level_name = "_register" if stropping and language_name == "cpp" else "register"
 
+    assert test_subject_module.filter_full_reference_name(ln, service_type) == "{}.getting.tired.of_0_1".format(
+        top_level_name
+    ).replace(".", namespace_separator)
     assert test_subject_module.filter_full_reference_name(
-        ln, service_type) == '{}.getting.tired.of_0_1'.format(top_level_name).replace('.', namespace_separator)
+        ln, service_request_type
+    ) == "{}.getting.tired.of.Python_0_1".format(top_level_name).replace(".", namespace_separator)
     assert test_subject_module.filter_full_reference_name(
-        ln, service_request_type) == '{}.getting.tired.of.Python_0_1'.format(top_level_name)\
-        .replace('.', namespace_separator)
-    assert test_subject_module.filter_full_reference_name(
-        ln, service_response_type) == '{}.getting.tired.of.Python_0_1'.format(top_level_name)\
-        .replace('.', namespace_separator)
+        ln, service_response_type
+    ) == "{}.getting.tired.of.Python_0_1".format(top_level_name).replace(".", namespace_separator)
 
 
 @typing.no_type_check
@@ -339,23 +387,20 @@ def test_filter_to_template_unique(gen_paths):
     Cover issue #88
     """
     root_path = str(gen_paths.dsdl_dir / Path("one"))
-    output_path = gen_paths.out_dir / 'to_unique'
+    output_path = gen_paths.out_dir / "to_unique"
     compound_types = read_namespace(root_path, [])
-    language_context = LanguageContext(target_language='c')
-    namespace = build_namespace_tree(compound_types,
-                                     root_path,
-                                     output_path,
-                                     language_context)
-    template_path = gen_paths.templates_dir / Path('to_unique')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("c").create()
+    namespace = build_namespace_tree(compound_types, root_path, output_path, language_context)
+    template_path = gen_paths.templates_dir / Path("to_unique")
     generator = DSDLCodeGenerator(namespace, templates_dir=template_path)
     generator.generate_all()
     outfile = gen_paths.find_outfile_in_namespace("one.foo", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    expected = '_f0_\n_f1_\n_f2_\n_f3_\n\n_f4_\n_f5_\n_f6_\n_f7_\n\n_f8_\n_f9_\n_f10_\n_f11_\n'
+    expected = "_f0_\n_f1_\n_f2_\n_f3_\n\n_f4_\n_f5_\n_f6_\n_f7_\n\n_f8_\n_f9_\n_f10_\n_f11_\n"
 
-    with open(str(outfile), 'r') as foo_file:
+    with open(str(outfile), "r") as foo_file:
         actual = foo_file.read()
 
     assert expected == actual

--- a/test/gentest_json/test_json.py
+++ b/test/gentest_json/test_json.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 from pydsdl import read_namespace
 from nunavut import build_namespace_tree
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder, Language
 from nunavut.jinja import DSDLCodeGenerator
 
 
 def test_TestType_0_1(gen_paths):  # type: ignore
-    """ Generates a JSON blob and then reads it back in.
+    """Generates a JSON blob and then reads it back in.
 
     This test uses an extremely simple DSDL type to generate JSON then
     reads this JSON back in and parses it using Python's built-in parser.
@@ -21,20 +21,23 @@ def test_TestType_0_1(gen_paths):  # type: ignore
 
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
     root_namespace = str(root_namespace_dir)
-    language_context = LanguageContext(extension='.json')
-    namespace = build_namespace_tree(read_namespace(root_namespace, []),
-                                     root_namespace_dir,
-                                     gen_paths.out_dir,
-                                     language_context)
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".json")
+        .create()
+    )
+    namespace = build_namespace_tree(
+        read_namespace(root_namespace, []), root_namespace_dir, gen_paths.out_dir, language_context
+    )
     generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)
 
     # Now read back in and verify
     outfile = gen_paths.find_outfile_in_namespace("uavcan.test.TestType", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None

--- a/test/gentest_lang/test_lang.py
+++ b/test/gentest_lang/test_lang.py
@@ -11,8 +11,8 @@ from unittest.mock import MagicMock
 import pytest
 from nunavut import build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import (Dependencies, Language, LanguageContext,
-                          LanguageLoader)
+from nunavut.dependencies import Dependencies
+from nunavut.lang import Language, LanguageContext, LanguageClassLoader, LanguageContextBuilder
 from nunavut.lang.c import filter_id as c_filter_id
 from nunavut.lang.cpp import filter_id as cpp_filter_id
 from nunavut.lang.py import filter_id as py_filter_id
@@ -21,7 +21,6 @@ from pydsdl import read_namespace
 
 
 class Dummy:
-
     def __init__(self, name: str) -> None:
         self._name = name
 
@@ -29,18 +28,19 @@ class Dummy:
     def name(self) -> str:
         return self._name
 
+
 # +---------------------------------------------------------------------------+
 # | PARAMETERIZED TESTS
 # +---------------------------------------------------------------------------+
 
 
-def ptest_lang_c(gen_paths: Any,
-                 implicit: bool,
-                 unique_name_evaluator: Any,
-                 use_standard_types: bool,
-                 configurable_language_context_factory: Callable) -> Dict:
-    """ Generates and verifies JSON with values filtered using the c language support module.
-    """
+def ptest_lang_c(
+    gen_paths: Any,
+    implicit: bool,
+    unique_name_evaluator: Any,
+    use_standard_types: bool,
+) -> Dict:
+    """Generates and verifies JSON with values filtered using the c language support module."""
 
     root_namespace_dir = gen_paths.dsdl_dir / Path("langtest")
     if implicit:
@@ -53,25 +53,26 @@ def ptest_lang_c(gen_paths: Any,
     root_namespace = str(root_namespace_dir)
     compound_types = read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
 
-    config_overrides = {'nunavut.lang.c': {'use_standard_types': use_standard_types}}
-    language_context = configurable_language_context_factory(config_overrides,
-                                                             'c' if implicit else None,
-                                                             '.h' if not implicit else None)
-    namespace = build_namespace_tree(compound_types,
-                                     root_namespace_dir,
-                                     gen_paths.out_dir,
-                                     language_context)
-    generator = DSDLCodeGenerator(namespace,
-                                  templates_dir=templates_dirs)
-    generator.generate_all(False)
+    builder = LanguageContextBuilder(include_experimental_languages=True).set_target_language_configuration_override(
+        "use_standard_types", use_standard_types
+    )
+    if implicit:
+        builder.set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".h")
+    else:
+        builder.set_target_language("c")
+
+    language_context = builder.create()
+    namespace = build_namespace_tree(compound_types, root_namespace_dir, gen_paths.out_dir, language_context)
+    generator = DSDLCodeGenerator(namespace, templates_dir=templates_dirs)
+    generator.generate_all()
 
     # Now read back in and verify
     outfile = gen_paths.find_outfile_in_namespace("langtest.c.TestType", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
     generated_values = {}  # type: Dict
-    with open(str(outfile), 'r') as python_file:
+    with open(str(outfile), "r") as python_file:
         exec(python_file.read(), generated_values)
 
     assert len(generated_values) > 0
@@ -104,17 +105,16 @@ def ptest_lang_c(gen_paths: Any,
 
     assert lang_c_output["ctype saturated bool"] == "bool"
 
-    unique_name_evaluator(r'_nAME\d+_', lang_c_output["unique_name_0"])
-    unique_name_evaluator(r'_nAME\d+_', lang_c_output["unique_name_1"])
-    unique_name_evaluator(r'_naME\d+_', lang_c_output["unique_name_2"])
-    unique_name_evaluator(r'_\d+_', lang_c_output["unique_name_3"])
+    unique_name_evaluator(r"_nAME\d+_", lang_c_output["unique_name_0"])
+    unique_name_evaluator(r"_nAME\d+_", lang_c_output["unique_name_1"])
+    unique_name_evaluator(r"_naME\d+_", lang_c_output["unique_name_2"])
+    unique_name_evaluator(r"_\d+_", lang_c_output["unique_name_3"])
 
     return generated_values
 
 
 def ptest_lang_cpp(gen_paths, implicit):  # type: ignore
-    """Generates and verifies JSON with values filtered using the cpp language module.
-    """
+    """Generates and verifies JSON with values filtered using the cpp language module."""
 
     root_namespace_dir = gen_paths.dsdl_dir / Path("langtest")
     root_namespace = str(root_namespace_dir)
@@ -126,52 +126,65 @@ def ptest_lang_cpp(gen_paths, implicit):  # type: ignore
 
     templates_dirs.append(gen_paths.templates_dir / Path("common"))
 
-    language_context = LanguageContext('cpp' if implicit else None, '.hpp' if not implicit else None)
+    builder = LanguageContextBuilder(include_experimental_languages=True)
+    if implicit:
+        builder.set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".hpp")
+    else:
+        builder.set_target_language("cpp")
 
-    namespace = build_namespace_tree(compound_types,
-                                     root_namespace_dir,
-                                     gen_paths.out_dir,
-                                     language_context)
+    language_context = builder.create()
 
-    generator = DSDLCodeGenerator(namespace,
-                                  templates_dir=templates_dirs)
+    namespace = build_namespace_tree(compound_types, root_namespace_dir, gen_paths.out_dir, language_context)
+
+    generator = DSDLCodeGenerator(namespace, templates_dir=templates_dirs)
 
     generator.generate_all(False)
 
     # Now read back in and verify
     outfile = gen_paths.find_outfile_in_namespace("langtest.cpp.ns.TestType", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
     generated_values = {}  # type: Dict
-    with open(str(outfile), 'r') as python_file:
+    with open(str(outfile), "r") as python_file:
         exec(python_file.read(), generated_values)
 
     assert len(generated_values)
 
     lang_cpp_output = generated_values["tests"]["lang_cpp"]
     assert lang_cpp_output["namespace"] == "langtest.cpp.ns"
-    assert lang_cpp_output["namespace_open"] == r'''namespace langtest
+    assert (
+        lang_cpp_output["namespace_open"]
+        == r"""namespace langtest
 {
 namespace cpp
 {
 namespace ns
-{'''
-    assert lang_cpp_output["namespace_open_wo_nl"] == r'''namespace langtest {
+{"""
+    )
+    assert (
+        lang_cpp_output["namespace_open_wo_nl"]
+        == r"""namespace langtest {
 namespace cpp {
-namespace ns {'''
-    assert lang_cpp_output["namespace_close"] == r'''}
+namespace ns {"""
+    )
+    assert (
+        lang_cpp_output["namespace_close"]
+        == r"""}
 }
-}'''
-    assert lang_cpp_output["namespace_close_w_comments"] == r'''} // namespace ns
+}"""
+    )
+    assert (
+        lang_cpp_output["namespace_close_w_comments"]
+        == r"""} // namespace ns
 } // namespace cpp
-} // namespace langtest'''
+} // namespace langtest"""
+    )
     return generated_values
 
 
 def ptest_lang_py(gen_paths, implicit, unique_name_evaluator):  # type: ignore
-    """ Generates and verifies JSON with values filtered using the python language support module.
-    """
+    """Generates and verifies JSON with values filtered using the python language support module."""
 
     root_namespace_dir = gen_paths.dsdl_dir / Path("langtest")
     root_namespace = str(root_namespace_dir)
@@ -184,112 +197,111 @@ def ptest_lang_py(gen_paths, implicit, unique_name_evaluator):  # type: ignore
 
     compound_types = read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
 
-    language_context = LanguageContext('py' if implicit else None, '.py' if not implicit else None)
+    builder = LanguageContextBuilder(include_experimental_languages=True)
+    if implicit:
+        builder.set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".py")
+    else:
+        builder.set_target_language("py")
 
-    namespace = build_namespace_tree(compound_types,
-                                     root_namespace_dir,
-                                     gen_paths.out_dir,
-                                     language_context)
-    generator = DSDLCodeGenerator(namespace,
-                                  generate_namespace_types=YesNoDefault.NO,
-                                  templates_dir=templates_dirs)
+    language_context = builder.create()
+
+    namespace = build_namespace_tree(compound_types, root_namespace_dir, gen_paths.out_dir, language_context)
+    generator = DSDLCodeGenerator(namespace, generate_namespace_types=YesNoDefault.NO, templates_dir=templates_dirs)
 
     generator.generate_all(False)
 
     # Now read back in and verify
     outfile = gen_paths.find_outfile_in_namespace("langtest.py.TestType", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
     generated_values = {}  # type: Dict
-    with open(str(outfile), 'r') as python_file:
+    with open(str(outfile), "r") as python_file:
         exec(python_file.read(), generated_values)
 
     assert len(generated_values) > 0
 
     lang_py_output = generated_values["tests"]["lang_py"]
-    unique_name_evaluator(r'_NAME\d+_', lang_py_output["unique_name_0"])
-    unique_name_evaluator(r'_NAME\d+_', lang_py_output["unique_name_1"])
-    unique_name_evaluator(r'_name\d+_', lang_py_output["unique_name_2"])
+    unique_name_evaluator(r"_NAME\d+_", lang_py_output["unique_name_0"])
+    unique_name_evaluator(r"_NAME\d+_", lang_py_output["unique_name_1"])
+    unique_name_evaluator(r"_name\d+_", lang_py_output["unique_name_2"])
     assert "identifier_zero" == lang_py_output["id_0"]
 
     many_unique_names = lang_py_output.get("many_unique_names")
     if many_unique_names is not None:
         for name in many_unique_names:
-            unique_name_evaluator(r'_f\d+_', name)
+            unique_name_evaluator(r"_f\d+_", name)
 
     return generated_values
+
 
 # +---------------------------------------------------------------------------+
 # | TESTS
 # +---------------------------------------------------------------------------+
 
 
-@pytest.mark.parametrize('implicit,use_standard_types', [(True, True), (True, False), (False, True), (False, False)])
-def test_lang_c(gen_paths: Any,
-                unique_name_evaluator: Any,
-                implicit: bool,
-                use_standard_types: bool,
-                configurable_language_context_factory: Callable) -> None:
+@pytest.mark.parametrize("implicit,use_standard_types", [(True, True), (True, False), (False, True), (False, False)])
+def test_lang_c(gen_paths: Any, unique_name_evaluator: Any, implicit: bool, use_standard_types: bool) -> None:
     """
     Generates and verifies JSON with values filtered using the c language support module.
     """
-    lctx = LanguageContext()
-
-    generated_values = ptest_lang_c(gen_paths, implicit, unique_name_evaluator,
-                                    use_standard_types, configurable_language_context_factory)
+    generated_values = ptest_lang_c(gen_paths, implicit, unique_name_evaluator, use_standard_types)
     if implicit:
         lang_any = generated_values["tests"]["lang_any"]
 
-        assert lang_any['id_0'] == 'zX003123_class__for_u2___zX0028zX002Aother_stuffzX002DzX0026zX002DsuchzX0029'
-        assert lang_any['id_1'] == '_reserved'
-        assert lang_any['id_2'] == '_also_reserved'
-        assert lang_any['id_3'] == '_register'
-        assert lang_any['id_4'] == 'False'
-        assert lang_any['id_5'] == '_return'
-        assert lang_any['id_7'] == 'I_zX2764_UAVCAN'
-        assert lang_any['id_8'] == 'zX0031_zX2764_UAVCAN'
+        assert lang_any["id_0"] == "zX003123_class__for_u2___zX0028zX002Aother_stuffzX002DzX0026zX002DsuchzX0029"
+        assert lang_any["id_1"] == "_reserved"
+        assert lang_any["id_2"] == "_also_reserved"
+        assert lang_any["id_3"] == "_register"
+        assert lang_any["id_4"] == "False"
+        assert lang_any["id_5"] == "_return"
+        assert lang_any["id_7"] == "I_zX2764_UAVCAN"
+        assert lang_any["id_8"] == "zX0031_zX2764_UAVCAN"
 
-        assert lang_any['id_9'] == 'str'
-        assert lang_any['id_A'] == '_strr'
-        assert lang_any['id_B'] == '_uINT_FOO_MIN'
-        assert lang_any['id_C'] == '_iNT_C'
-        assert lang_any['id_D'] == 'LC_Is_reserved'
-        assert lang_any['id_E'] == 'NOT_ATOMIC_YO'
-        assert lang_any['id_F'] == '_aTOMIC_YO'
-        assert lang_any['id_G'] == '_memory_order_yo'
+        assert lang_any["id_9"] == "str"
+        assert lang_any["id_A"] == "_strr"
+        assert lang_any["id_B"] == "_uINT_FOO_MIN"
+        assert lang_any["id_C"] == "_iNT_C"
+        assert lang_any["id_D"] == "LC_Is_reserved"
+        assert lang_any["id_E"] == "NOT_ATOMIC_YO"
+        assert lang_any["id_F"] == "_aTOMIC_YO"
+        assert lang_any["id_G"] == "_memory_order_yo"
 
-    assert '_flight__time' == c_filter_id(lctx.get_language('nunavut.lang.c'), Dummy('_Flight__time'))
+    lctx = LanguageContextBuilder().set_target_language("c").create()
+    assert "_flight__time" == c_filter_id(lctx.get_target_language(), Dummy("_Flight__time"))
 
 
 def test_lang_cpp(gen_paths):  # type: ignore
     """
     Generates and verifies JSON with values filtered using the cpp language module.
     """
-    lctx = LanguageContext()
-
     generated_values = ptest_lang_cpp(gen_paths, True)
     lang_any = generated_values["tests"]["lang_any"]
 
-    assert lang_any['id_0'] == '_123_class_for_u2_zX0028zX002Aother_stuffzX002DzX0026zX002DsuchzX0029'
-    assert lang_any['id_1'] == '_reserved'
-    assert lang_any['id_2'] == 'zX005FzX005Falso_reserved'
-    assert lang_any['id_3'] == '_register'
-    assert lang_any['id_4'] == 'False'
-    assert lang_any['id_5'] == '_return'
-    assert lang_any['id_7'] == 'I_zX2764_UAVCAN'
-    assert lang_any['id_8'] == '_1_zX2764_UAVCAN'
-    assert lang_any['id_9'] == 'str'
-    assert lang_any['id_A'] == 'strr'
-    assert lang_any['id_B'] == '_uINT_FOO_MIN'
-    assert lang_any['id_C'] == '_iNT_C'
-    assert lang_any['id_D'] == 'LC_Is_reserved'
-    assert lang_any['id_E'] == 'NOT_ATOMIC_YO'
-    assert lang_any['id_F'] == '_aTOMIC_YO'
+    assert lang_any["id_0"] == "_123_class_for_u2_zX0028zX002Aother_stuffzX002DzX0026zX002DsuchzX0029"
+    assert lang_any["id_1"] == "_reserved"
+    assert lang_any["id_2"] == "zX005FzX005Falso_reserved"
+    assert lang_any["id_3"] == "_register"
+    assert lang_any["id_4"] == "False"
+    assert lang_any["id_5"] == "_return"
+    assert lang_any["id_7"] == "I_zX2764_UAVCAN"
+    assert lang_any["id_8"] == "_1_zX2764_UAVCAN"
+    assert lang_any["id_9"] == "str"
+    assert lang_any["id_A"] == "strr"
+    assert lang_any["id_B"] == "_uINT_FOO_MIN"
+    assert lang_any["id_C"] == "_iNT_C"
+    assert lang_any["id_D"] == "LC_Is_reserved"
+    assert lang_any["id_E"] == "NOT_ATOMIC_YO"
+    assert lang_any["id_F"] == "_aTOMIC_YO"
 
-    lang_cpp = lctx.get_language('nunavut.lang.cpp')
+    lang_cpp = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("cpp")
+        .create()
+        .get_target_language()
+    )
 
-    assert '_flight_time' == cpp_filter_id(lang_cpp, Dummy('_Flight_time'))
+    assert "_flight_time" == cpp_filter_id(lang_cpp, Dummy("_Flight_time"))
 
 
 def test_lang_cpp_explicit(gen_paths):  # type: ignore
@@ -302,30 +314,30 @@ def test_lang_cpp_explicit(gen_paths):  # type: ignore
 
 
 def test_lang_py_implicit(gen_paths, unique_name_evaluator):  # type: ignore
-    """ Generates and verifies JSON with values filtered using the python language support module.
-    """
-    lctx = LanguageContext()
+    """Generates and verifies JSON with values filtered using the python language support module."""
 
     generated_values = ptest_lang_py(gen_paths, True, unique_name_evaluator)
     lang_any = generated_values["tests"]["lang_any"]
 
-    assert lang_any['id_0'] == 'zX003123_class__for_u2___zX0028zX002Aother_stuffzX002DzX0026zX002DsuchzX0029'
-    assert lang_any['id_1'] == '_Reserved'
-    assert lang_any['id_2'] == '__also_reserved'
-    assert lang_any['id_3'] == 'register'
-    assert lang_any['id_4'] == 'False_'
-    assert lang_any['id_5'] == 'return_'
-    assert lang_any['id_7'] == 'I_zX2764_UAVCAN'
-    assert lang_any['id_8'] == 'zX0031_zX2764_UAVCAN'
-    assert lang_any['id_9'] == 'str_'
-    assert lang_any['id_A'] == 'strr'
-    assert lang_any['id_B'] == 'UINT_FOO_MIN'
-    assert lang_any['id_C'] == 'INT_C'
-    assert lang_any['id_D'] == 'LC_Is_reserved'
-    assert lang_any['id_E'] == 'NOT_ATOMIC_YO'
-    assert lang_any['id_F'] == 'ATOMIC_YO'
+    assert lang_any["id_0"] == "zX003123_class__for_u2___zX0028zX002Aother_stuffzX002DzX0026zX002DsuchzX0029"
+    assert lang_any["id_1"] == "_Reserved"
+    assert lang_any["id_2"] == "__also_reserved"
+    assert lang_any["id_3"] == "register"
+    assert lang_any["id_4"] == "False_"
+    assert lang_any["id_5"] == "return_"
+    assert lang_any["id_7"] == "I_zX2764_UAVCAN"
+    assert lang_any["id_8"] == "zX0031_zX2764_UAVCAN"
+    assert lang_any["id_9"] == "str_"
+    assert lang_any["id_A"] == "strr"
+    assert lang_any["id_B"] == "UINT_FOO_MIN"
+    assert lang_any["id_C"] == "INT_C"
+    assert lang_any["id_D"] == "LC_Is_reserved"
+    assert lang_any["id_E"] == "NOT_ATOMIC_YO"
+    assert lang_any["id_F"] == "ATOMIC_YO"
 
-    assert '_Flight__time' == py_filter_id(lctx.get_language('nunavut.lang.py'), Dummy('_Flight__time'))
+    lctx = LanguageContextBuilder().set_target_language("py").create()
+
+    assert "_Flight__time" == py_filter_id(lctx.get_target_language(), Dummy("_Flight__time"))
 
 
 def test_lang_py_explicit(gen_paths, unique_name_evaluator):  # type: ignore
@@ -344,40 +356,45 @@ def test_language_object() -> None:
     mock_config = MagicMock()
 
     class TestLang(Language):
-
         def get_includes(self, deps: Dependencies) -> List[str]:
             return []
 
+    language = TestLang(LanguageClassLoader.to_language_module_name("c"), mock_config)
 
+    assert "c" == language.name
 
-    language = TestLang(LanguageLoader.load_language_module('c'), mock_config, True)
-
-    assert 'c' == language.name
-
-    assert language.omit_serialization_support
+    assert language.stable_support
 
 
 def test_language_context() -> None:
     """
     Verify that the LanguageContext objects works as required.
     """
-    context_w_no_target = LanguageContext(extension='.json')
 
-    assert None is context_w_no_target.get_target_language()
-    assert 'c' in context_w_no_target.get_supported_languages()
-    assert 'cpp' in context_w_no_target.get_supported_languages()
-    assert 'py' in context_w_no_target.get_supported_languages()
+    context_w_no_target = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .create()
+    )
 
-    assert 'if' == context_w_no_target.filter_id_for_target('if', '')
+    assert None is not context_w_no_target.get_target_language()
+    assert "c" in context_w_no_target.get_supported_languages()
+    assert "cpp" in context_w_no_target.get_supported_languages()
+    assert "py" in context_w_no_target.get_supported_languages()
 
-    context_w_target = LanguageContext('c')
+    assert "foo" == context_w_no_target.filter_id_for_target("foo", "")
+
+    context_w_target = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("c")
+        .create()
+    )
 
     assert context_w_target.get_target_language() is not None
 
     target_language = context_w_target.get_target_language()
     assert target_language is not None
-    target_named_types = target_language.get_named_types()
-    assert 'byte' in target_named_types
+    target_named_types = target_language.named_types
+    assert "byte" in target_named_types
 
 
 def test_either_target_or_extension() -> None:
@@ -385,12 +402,32 @@ def test_either_target_or_extension() -> None:
     LanguageContext requires either a target or an extension or both but not
     neither.
     """
-    _ = LanguageContext(target_language='py')
-    _ = LanguageContext(extension='.py')
-    _ = LanguageContext(target_language='py', extension='.py')
-    text_extension = LanguageContext()
-    with pytest.raises(RuntimeError):
-        _ = text_extension.get_output_extension()
 
-    with pytest.raises(KeyError):
-        _ = LanguageContext('foobar')
+    assert "py" == (
+        LanguageContextBuilder()
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".py")
+        .create()
+        .get_target_language()
+        .name
+    )
+    assert "py" == (
+        LanguageContextBuilder()
+        .set_target_language("py")
+        .create()
+        .get_target_language()
+        .name
+    )
+    assert "py" == (
+        LanguageContextBuilder()
+        .set_target_language("py")
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".py")
+        .create()
+        .get_target_language()
+        .name
+    )
+    assert LanguageContextBuilder.DEFAULT_TARGET_LANGUAGE == (
+        LanguageContextBuilder()
+        .create()
+        .get_target_language()
+        .name
+    )

--- a/test/gentest_lookup/test_lookup.py
+++ b/test/gentest_lookup/test_lookup.py
@@ -10,7 +10,7 @@ import json
 
 from pydsdl import read_namespace
 from nunavut import build_namespace_tree, Namespace
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder
 from nunavut.jinja import DSDLCodeGenerator
 from nunavut.jinja.loaders import TEMPLATE_SUFFIX
 
@@ -35,7 +35,7 @@ def test_bfs_of_type_for_template(gen_paths):  # type: ignore
     """ Verifies that our template to type lookup logic does a breadth-first search for a valid
     template when searching type names.
     """
-    language_context = LanguageContext(extension='.json')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
     empty_namespace = Namespace('',
                                 gen_paths.dsdl_dir,
                                 gen_paths.out_dir,
@@ -54,7 +54,7 @@ def test_one_template(gen_paths):  # type: ignore
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
     root_namespace = str(root_namespace_dir)
     serializable_types = read_namespace(root_namespace, [])
-    language_context = LanguageContext(extension='.json')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
     namespace = build_namespace_tree(serializable_types,
                                      root_namespace_dir,
                                      gen_paths.out_dir,
@@ -79,7 +79,7 @@ def test_get_templates(gen_paths):  # type: ignore
     root_namespace_dir = gen_paths.dsdl_dir / Path("uavcan")
     root_namespace = str(root_namespace_dir)
     serializable_types = read_namespace(root_namespace, [])
-    language_context = LanguageContext(extension='.json')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("c").create()
     namespace = build_namespace_tree(serializable_types,
                                      root_namespace_dir,
                                      gen_paths.out_dir,

--- a/test/gentest_multiple/test_multiple.py
+++ b/test/gentest_multiple/test_multiple.py
@@ -12,7 +12,7 @@ from pydsdl import FrontendError, read_namespace
 
 from nunavut import build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder
 
 
 def test_two_root_error(gen_paths):  # type: ignore
@@ -31,7 +31,7 @@ def test_three_roots(gen_paths):  # type: ignore
     includes = [str(gen_paths.dsdl_dir / Path("huckco")),
                 str(gen_paths.dsdl_dir / Path("esmeinc"))]
     compound_types = read_namespace(root_namespace, includes, allow_unregulated_fixed_port_id=True)
-    language_context = LanguageContext(extension='.json')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
     namespace = build_namespace_tree(compound_types,
                                      root_namespace,
                                      gen_paths.out_dir,

--- a/test/gentest_namespaces/test_namespaces.py
+++ b/test/gentest_namespaces/test_namespaces.py
@@ -10,17 +10,17 @@ from pathlib import Path
 
 import pytest
 from nunavut import Namespace, build_namespace_tree
-from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import LanguageContext
 from nunavut._utilities import YesNoDefault
+from nunavut.jinja import DSDLCodeGenerator
+from nunavut.lang import Language, LanguageContext, LanguageContextBuilder
 from pydsdl import Any, CompositeType, read_namespace
 
 
 class DummyType(Any):
     """Fake dsdl 'any' type for testing."""
 
-    def __init__(self, namespace: str = 'uavcan', name: str = 'Dummy'):
-        self._full_name = '{}.{}'.format(namespace, name)
+    def __init__(self, namespace: str = "uavcan", name: str = "Dummy"):
+        self._full_name = "{}.{}".format(namespace, name)
 
     # +-----------------------------------------------------------------------+
     # | DUCK TYPEING: CompositeType
@@ -46,22 +46,24 @@ class DummyType(Any):
         return hash(self._full_name)
 
 
-def gen_test_namespace(gen_paths: typing.Any, language_context: LanguageContext) -> \
-        typing.Tuple[Namespace, str, typing.List[CompositeType]]:
+def gen_test_namespace(
+    gen_paths: typing.Any, language_context: LanguageContext
+) -> typing.Tuple[Namespace, str, typing.List[CompositeType]]:
     root_namespace_path = str(gen_paths.dsdl_dir / Path("scotec"))
     includes = [str(gen_paths.dsdl_dir / Path("uavcan"))]
     compound_types = read_namespace(root_namespace_path, includes, allow_unregulated_fixed_port_id=True)
-    return build_namespace_tree(compound_types,
-                                root_namespace_path,
-                                gen_paths.out_dir,
-                                language_context), root_namespace_path, compound_types
+    return (
+        build_namespace_tree(compound_types, root_namespace_path, gen_paths.out_dir, language_context),
+        root_namespace_path,
+        compound_types,
+    )
 
 
 def test_namespace_eq(gen_paths):  # type: ignore
     """Verify the get_all_namespaces method in Namespace"""
-    language_context = LanguageContext(extension='.json')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
     namespace0, _, _ = gen_test_namespace(gen_paths, language_context)
-    namespace1 = Namespace('', gen_paths.dsdl_dir, gen_paths.out_dir, language_context)
+    namespace1 = Namespace("", gen_paths.dsdl_dir, gen_paths.out_dir, language_context)
     assert namespace0 == namespace0
     assert namespace1 == namespace1
     assert namespace0 != namespace1
@@ -70,7 +72,8 @@ def test_namespace_eq(gen_paths):  # type: ignore
 
 def test_get_all_namespaces(gen_paths):  # type: ignore
     """Verify the get_all_namespaces method in Namespace"""
-    namespace, _, _ = gen_test_namespace(gen_paths, LanguageContext(extension='.json'))
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
+    namespace, _, _ = gen_test_namespace(gen_paths, language_context)
     index = dict()
     for ns, path in namespace.get_all_namespaces():
         index[path] = ns
@@ -80,7 +83,8 @@ def test_get_all_namespaces(gen_paths):  # type: ignore
 
 def test_get_all_types(gen_paths):  # type: ignore
     """Verify the get_all_namespaces method in Namespace"""
-    namespace, _, _ = gen_test_namespace(gen_paths, LanguageContext(extension='.json'))
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
+    namespace, _, _ = gen_test_namespace(gen_paths, language_context)
     index = dict()
     for ns, path in namespace.get_all_types():
         index[path] = ns
@@ -90,12 +94,18 @@ def test_get_all_types(gen_paths):  # type: ignore
 
 def test_empty_namespace(gen_paths):  # type: ignore
     """Test a namespace object with no children."""
-    namespace = Namespace('', gen_paths.dsdl_dir, gen_paths.out_dir, LanguageContext(extension='.txt'))
-    assert namespace.full_name == ''
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".txt")
+        .set_target_language_configuration_override(Language.WKCV_NAMESPACE_FILE_STEM, "_")
+        .create()
+    )
+    namespace = Namespace("", gen_paths.dsdl_dir, gen_paths.out_dir, language_context)
+    assert namespace.full_name == ""
     assert namespace.output_folder == gen_paths.out_dir
     assert namespace.source_file_path == gen_paths.dsdl_dir
     assert len(namespace.data_types) == 0
-    assert (gen_paths.out_dir / Path('_')).with_suffix('.txt') == namespace.find_output_path_for_type(namespace)
+    assert (gen_paths.out_dir / Path("_")).with_suffix(".txt") == namespace.find_output_path_for_type(namespace)
     assert namespace == namespace
     assert hash(namespace) == hash(namespace)
     assert str(namespace) == str(namespace)
@@ -104,99 +114,100 @@ def test_empty_namespace(gen_paths):  # type: ignore
 
 
 def parameterized_test_namespace_(gen_paths, templates_subdir):  # type: ignore
-    language_context = LanguageContext(extension='.json')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
     namespace, root_namespace_path, _ = gen_test_namespace(gen_paths, language_context)
-    generator = DSDLCodeGenerator(namespace,
-                                  generate_namespace_types=YesNoDefault.NO,
-                                  templates_dir=gen_paths.templates_dir / Path(templates_subdir))
+    generator = DSDLCodeGenerator(
+        namespace,
+        generate_namespace_types=YesNoDefault.NO,
+        templates_dir=gen_paths.templates_dir / Path(templates_subdir),
+    )
     generator.generate_all()
     assert namespace.source_file_path == Path(root_namespace_path)
-    assert namespace.full_name == 'scotec'
+    assert namespace.full_name == "scotec"
     for nested_namespace in namespace.get_nested_namespaces():
-        nested_namespace_path = Path(root_namespace_path) / Path(*nested_namespace.full_name.split('.')[1:])
+        nested_namespace_path = Path(root_namespace_path) / Path(*nested_namespace.full_name.split(".")[1:])
         assert nested_namespace.source_file_path == nested_namespace_path
 
 
 def test_namespace_any_template(gen_paths):  # type: ignore
     """Basic test of a non-empty namespace using the Any.j2 template."""
-    parameterized_test_namespace_(gen_paths, 'default')
+    parameterized_test_namespace_(gen_paths, "default")
 
 
 def test_namespace_namespace_template(gen_paths):  # type: ignore
     """Basic test of a non-empty namespace using the Namespace.j2 template."""
-    parameterized_test_namespace_(gen_paths, 'namespace')
+    parameterized_test_namespace_(gen_paths, "namespace")
 
 
 def test_namespace_generation(gen_paths):  # type: ignore
     """Test actually generating a namepace file."""
-    language_context = LanguageContext(extension='.json', namespace_output_stem='__module__')
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("js")
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, ".json")
+        .set_target_language_configuration_override(Language.WKCV_NAMESPACE_FILE_STEM, "__module__")
+        .create()
+    )
     namespace, root_namespace_path, compound_types = gen_test_namespace(gen_paths, language_context)
     assert len(compound_types) == 2
-    generator = DSDLCodeGenerator(namespace,
-                                  generate_namespace_types=YesNoDefault.YES,
-                                  templates_dir=gen_paths.templates_dir / Path('default'))
+    generator = DSDLCodeGenerator(
+        namespace, generate_namespace_types=YesNoDefault.YES, templates_dir=gen_paths.templates_dir / Path("default")
+    )
     generator.generate_all()
     for nested_namespace in namespace.get_nested_namespaces():
-        nested_namespace_path = Path(root_namespace_path) / Path(*nested_namespace.full_name.split('.')[1:])
+        nested_namespace_path = Path(root_namespace_path) / Path(*nested_namespace.full_name.split(".")[1:])
         assert nested_namespace.source_file_path == nested_namespace_path
 
     outfile = gen_paths.find_outfile_in_namespace("scotec.mcu", namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['scotec.mcu']['namespace'] == 'scotec.mcu'
+    assert json_blob["scotec.mcu"]["namespace"] == "scotec.mcu"
 
     output_path_for_timer = namespace.find_output_path_for_type(compound_types[0])
-    assert (gen_paths.out_dir / 'scotec' / 'mcu' / 'Timer_0_1').with_suffix('.json') == output_path_for_timer
+    assert (gen_paths.out_dir / "scotec" / "mcu" / "Timer_0_1").with_suffix(".json") == output_path_for_timer
 
 
 def test_build_namespace_tree_from_nothing(gen_paths):  # type: ignore
-    namespace = build_namespace_tree([], str(gen_paths.dsdl_dir), gen_paths.out_dir, LanguageContext('js'))
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language("js").create()
+    namespace = build_namespace_tree([], str(gen_paths.dsdl_dir), gen_paths.out_dir, language_context)
     assert namespace is not None
-    assert namespace.full_name == ''
+    assert namespace.full_name == ""
 
 
-@pytest.mark.parametrize('language_key,expected_file_ext,expected_stropp_part_0,expected_stropp_part_1',
-                         [('c', '.h', '_typedef', 'str'), ('py', '.py', 'typedef', 'str_')])  # type: ignore
-def test_namespace_stropping(gen_paths,
-                             language_key,
-                             expected_file_ext,
-                             expected_stropp_part_0,
-                             expected_stropp_part_1):
+@pytest.mark.parametrize(
+    "language_key,expected_file_ext,expected_stropp_part_0,expected_stropp_part_1",
+    [("c", ".h", "_typedef", "str"), ("py", ".py", "typedef", "str_")],
+)  # type: ignore
+def test_namespace_stropping(
+    gen_paths, language_key, expected_file_ext, expected_stropp_part_0, expected_stropp_part_1
+):
     """Test generating a namespace that uses a reserved keyword for a given language."""
-    language_context = LanguageContext(language_key)
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True).set_target_language(language_key).create()
+    )
     namespace, root_namespace_path, compound_types = gen_test_namespace(gen_paths, language_context)
     assert len(compound_types) == 2
-    generator = DSDLCodeGenerator(namespace,
-                                  generate_namespace_types=YesNoDefault.YES,
-                                  templates_dir=gen_paths.templates_dir / Path('default'))
+    generator = DSDLCodeGenerator(
+        namespace, generate_namespace_types=YesNoDefault.YES, templates_dir=gen_paths.templates_dir / Path("default")
+    )
     generator.generate_all()
 
-    expected_stropped_ns = 'scotec.{}.{}'.format(expected_stropp_part_0, expected_stropp_part_1)
+    expected_stropped_ns = "scotec.{}.{}".format(expected_stropp_part_0, expected_stropp_part_1)
     outfile = gen_paths.find_outfile_in_namespace(expected_stropped_ns, namespace)
 
-    assert (outfile is not None)
+    assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
 
     output_path_for_stropped = namespace.find_output_path_for_type(compound_types[1])
-    expected_stable_path = gen_paths.out_dir / 'scotec'
-    expected_path_and_file = expected_stable_path / expected_stropp_part_0 / expected_stropp_part_1 / 'ATOMIC_TYPE_0_1'
+    expected_stable_path = gen_paths.out_dir / "scotec"
+    expected_path_and_file = expected_stable_path / expected_stropp_part_0 / expected_stropp_part_1 / "ATOMIC_TYPE_0_1"
     assert expected_path_and_file.with_suffix(expected_file_ext) == output_path_for_stropped
-
-
-def test_python35_resolve_behavior(gen_paths):  # type: ignore
-    """Make sure Python3.5 and Python 3.6 throw the same exception here."""
-    language_context = LanguageContext('c')
-    with pytest.raises(FileNotFoundError):
-        Namespace('foo.bar',
-                  gen_paths.dsdl_dir / Path("scotec"),
-                  gen_paths.out_dir,
-                  language_context)

--- a/test/gentest_nnvg/test_nnvg.py
+++ b/test/gentest_nnvg/test_nnvg.py
@@ -13,6 +13,7 @@ import pytest
 
 import nunavut.version
 
+
 @pytest.mark.parametrize('env_var_name', ["UAVCAN_DSDL_INCLUDE_PATH", "DSDL_INCLUDE_PATH"])
 def test_UAVCAN_DSDL_INCLUDE_PATH(gen_paths: typing.Any, run_nnvg: typing.Callable, env_var_name: str) -> None:
     """
@@ -24,8 +25,8 @@ def test_UAVCAN_DSDL_INCLUDE_PATH(gen_paths: typing.Any, run_nnvg: typing.Callab
         gen_paths.templates_dir.as_posix(),
         "-O",
         gen_paths.out_dir.as_posix(),
-        "-e",
-        ".json",
+        "-l",
+        "js",
         "-Xlang",
         (gen_paths.dsdl_dir / pathlib.Path("uavcan")).as_posix(),
     ]
@@ -49,8 +50,8 @@ def test_nnvg_heals_missing_dot_in_extension(gen_paths: typing.Any, run_nnvg: ty
         gen_paths.templates_dir.as_posix(),
         "-O",
         gen_paths.out_dir.as_posix(),
-        "-e",
-        "json",
+        "-l",
+        "js",
         "-Xlang",
         "-I",
         (gen_paths.dsdl_dir / pathlib.Path("scotec")).as_posix(),
@@ -79,8 +80,9 @@ def test_list_inputs(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:
         gen_paths.templates_dir.as_posix(),
         "-O",
         gen_paths.out_dir.as_posix(),
-        "-e",
-        ".json",
+        "--target-language",
+        "c",
+        "--omit-serialization-support",
         "-I",
         (gen_paths.dsdl_dir / pathlib.Path("scotec")).as_posix(),
         "--list-inputs",
@@ -112,8 +114,10 @@ def test_list_inputs_w_namespaces(gen_paths: typing.Any, run_nnvg: typing.Callab
         gen_paths.templates_dir.as_posix(),
         "-O",
         gen_paths.out_dir.as_posix(),
-        "-e",
-        ".json",
+        "-l",
+        "js",
+        "-Xlang",
+        "--omit-serialization-support",
         "-I",
         (gen_paths.dsdl_dir / pathlib.Path("scotec")).as_posix(),
         "--list-inputs",
@@ -141,7 +145,10 @@ def test_list_outputs(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:
         gen_paths.out_dir.as_posix(),
         "-e",
         ".json",
+        "-l",
+        "js",
         "-Xlang",
+        "--omit-serialization-support",
         "-I",
         (gen_paths.dsdl_dir / pathlib.Path("scotec")).as_posix(),
         "--list-outputs",
@@ -529,8 +536,8 @@ def test_issue_116(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:
     nnvg_args = [
         "-O",
         gen_paths.out_dir.as_posix(),
-        "-e",
-        ".blarg",
+        "-l",
+        "blarg",
         "-I",
         (gen_paths.dsdl_dir / pathlib.Path("scotec")).as_posix(),
         "--list-outputs",
@@ -543,7 +550,7 @@ def test_issue_116(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:
         pytest.fail("nnvg completed normally when it should have failed to find a template.")
     except subprocess.CalledProcessError as e:
         error_output = e.stderr.decode("UTF-8")
-        assert "No target language was given" in error_output
+        assert "language blarg is not a supported language" in error_output
 
 
 def test_language_allow_unregulated_fixed_portid(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:

--- a/test/gentest_postprocessors/test_postprocessors.py
+++ b/test/gentest_postprocessors/test_postprocessors.py
@@ -17,30 +17,36 @@ import pytest
 import nunavut
 import nunavut.jinja
 import nunavut.postprocessors
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder, Language
 
 
-def _test_common_namespace(gen_paths,  # type: ignore
-                           target_language: str = 'js',
-                           extension: str = '.json',
-                           additional_config: typing.Optional[typing.Mapping[str, str]] = None):
+def _test_common_namespace(
+    gen_paths: typing.Any,
+    target_language: str = "js",
+    extension: str = ".json",
+    additional_config: typing.Optional[typing.Mapping[str, str]] = None,
+) -> nunavut.Namespace:
     root_namespace_dir = gen_paths.dsdl_dir / pathlib.Path("uavcan")
     root_namespace = str(root_namespace_dir)
-    lctx = LanguageContext(target_language, extension=extension)
+    lctx = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language(target_language)
+        .set_target_language_configuration_override(Language.WKCV_DEFINITION_FILE_EXTENSION, extension)
+        .create()
+    )
     if additional_config is not None:
-        ln_package_name = 'nunavut.lang.{}'.format(target_language)
+        ln_package_name = "nunavut.lang.{}".format(target_language)
         for name, value in additional_config.items():
             lctx.config.set(ln_package_name, name, value)
-    return nunavut.build_namespace_tree(pydsdl.read_namespace(root_namespace, []),
-                                        root_namespace_dir,
-                                        gen_paths.out_dir,
-                                        lctx)
+    return nunavut.build_namespace_tree(
+        pydsdl.read_namespace(root_namespace, []), root_namespace_dir, gen_paths.out_dir, lctx
+    )
 
 
 def _assert_no_empty_lines(outfile):  # type: ignore
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         for line in json_file:
-            line_end_match = re.search(r'\n|\r\n', line)
+            line_end_match = re.search(r"\n|\r\n", line)
             if line_end_match is not None:
                 assert len(line) > line_end_match.end() - line_end_match.start()
             else:
@@ -48,9 +54,9 @@ def _assert_no_empty_lines(outfile):  # type: ignore
 
 
 def _assert_no_trailing_whitespace(outfile):  # type: ignore
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         for line in json_file:
-            assert re.search(r' +$', line) is None
+            assert re.search(r" +$", line) is None
 
 
 def _test_common_post_condition(gen_paths, namespace):  # type: ignore
@@ -58,18 +64,17 @@ def _test_common_post_condition(gen_paths, namespace):  # type: ignore
     outfile = gen_paths.find_outfile_in_namespace("uavcan.test.TestType", namespace)
     assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['name0'] == 'uavcan.test.TestType.0.2'
+    assert json_blob["name0"] == "uavcan.test.TestType.0.2"
 
     return outfile
 
 
 def test_abs():  # type: ignore
-    """ Require that PostProcessor and intermediate types are abstract.
-    """
+    """Require that PostProcessor and intermediate types are abstract."""
     with pytest.raises(TypeError):
         nunavut.postprocessors.PostProcessor()  # type: ignore
     with pytest.raises(TypeError):
@@ -79,7 +84,7 @@ def test_abs():  # type: ignore
 
 
 def test_unknown_intermediate(gen_paths):  # type: ignore
-    """ Verifies that a ValueError is raised if something other than
+    """Verifies that a ValueError is raised if something other than
     LinePostProcessor or FilePostProcessor is provided to the jinja2 generator.
     """
 
@@ -91,32 +96,28 @@ def test_unknown_intermediate(gen_paths):  # type: ignore
             return generated
 
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[InvalidType()])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[InvalidType()]
+    )
     with pytest.raises(ValueError):
         generator.generate_all(False, True)
 
 
 def test_empty_pp_array(gen_paths):  # type: ignore
-    """ Verifies the behavior of a zero length post_processors argument.
-    """
+    """Verifies the behavior of a zero length post_processors argument."""
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[])
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir, post_processors=[])
     generator.generate_all(False, True)
 
     _test_common_post_condition(gen_paths, namespace)
 
 
 def test_chmod(gen_paths):  # type: ignore
-    """ Generates a file using a SetFileMode post-processor.
-    """
+    """Generates a file using a SetFileMode post-processor."""
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[nunavut.postprocessors.SetFileMode(0o444)]
+    )
     generator.generate_all(False, True)
 
     outfile = _test_common_post_condition(gen_paths, namespace)
@@ -125,12 +126,11 @@ def test_chmod(gen_paths):  # type: ignore
 
 
 def test_overwrite(gen_paths):  # type: ignore
-    """ Verifies the allow_overwrite flag contracts.
-    """
+    """Verifies the allow_overwrite flag contracts."""
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[nunavut.postprocessors.SetFileMode(0o444)]
+    )
     generator.generate_all(False, True)
 
     with pytest.raises(PermissionError):
@@ -142,12 +142,11 @@ def test_overwrite(gen_paths):  # type: ignore
 
 
 def test_overwrite_dryrun(gen_paths):  # type: ignore
-    """ Verifies the allow_overwrite flag contracts.
-    """
+    """Verifies the allow_overwrite flag contracts."""
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[nunavut.postprocessors.SetFileMode(0o444)])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[nunavut.postprocessors.SetFileMode(0o444)]
+    )
     generator.generate_all(False, True)
 
     with pytest.raises(PermissionError):
@@ -157,38 +156,49 @@ def test_overwrite_dryrun(gen_paths):  # type: ignore
 
 
 def test_no_overwrite_arg(gen_paths, run_nnvg):  # type: ignore
-    """ Verifies the --no-overwrite argument of nnvg.
-    """
-    nnvg_cmd = ['--templates', str(gen_paths.templates_dir),
-                '-O', str(gen_paths.out_dir),
-                '-e', '.json',
-                str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    """Verifies the --no-overwrite argument of nnvg."""
+    nnvg_cmd = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_cmd)
 
-    nnvg_cmd.append('--no-overwrite')
+    nnvg_cmd.append("--no-overwrite")
 
     with pytest.raises(subprocess.CalledProcessError):
         run_nnvg(gen_paths, nnvg_cmd, raise_called_process_error=True)
 
 
 def test_file_mode(gen_paths, run_nnvg):  # type: ignore
-    """ Verify the --file-mode argument of nnvg.
-    """
+    """Verify the --file-mode argument of nnvg."""
 
     file_mode = 0o574
-    nnvg_cmd = ['--templates', str(gen_paths.templates_dir),
-                '-O', str(gen_paths.out_dir),
-                '-e', '.json',
-                '--file-mode', oct(file_mode),
-                str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_cmd = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        "--file-mode",
+        oct(file_mode),
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_cmd)
 
-    outfile = gen_paths.out_dir /\
-        pathlib.Path('uavcan') /\
-        pathlib.Path('test') /\
-        pathlib.Path('TestType_0_2').with_suffix('.json')
+    outfile = (
+        gen_paths.out_dir
+        / pathlib.Path("uavcan")
+        / pathlib.Path("test")
+        / pathlib.Path("TestType_0_2").with_suffix(".json")
+    )
 
     outfile_stat_mode = pathlib.Path(outfile).stat().st_mode
     if os.name != "nt":
@@ -222,13 +232,13 @@ def test_move_file(gen_paths):  # type: ignore
             self.generated_path = generated
             return generated
 
-    mover = Mover(gen_paths.out_dir / pathlib.Path('moved').with_suffix('.json'))
+    mover = Mover(gen_paths.out_dir / pathlib.Path("moved").with_suffix(".json"))
     verifier = Verifier()
 
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[mover, verifier])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[mover, verifier]
+    )
     generator.generate_all(False, True)
 
     assert mover.called
@@ -242,10 +252,9 @@ def test_line_pp(gen_paths):  # type: ignore
     """
 
     class TestLinePostProcessor0(nunavut.postprocessors.LinePostProcessor):
-
         def __call__(self, line_and_lineend: typing.Tuple[str, str]) -> typing.Tuple[str, str]:
             if len(line_and_lineend[0]) == 0:
-                return ('', '')
+                return ("", "")
             else:
                 return line_and_lineend
 
@@ -260,9 +269,9 @@ def test_line_pp(gen_paths):  # type: ignore
     line_pp0 = TestLinePostProcessor0()
     line_pp1 = TestLinePostProcessor1()
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[line_pp0, line_pp1])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[line_pp0, line_pp1]
+    )
     generator.generate_all(False, True)
     assert len(line_pp1._lines) > 0
     _test_common_post_condition(gen_paths, namespace)
@@ -270,23 +279,24 @@ def test_line_pp(gen_paths):  # type: ignore
 
 def test_line_pp_returns_none(gen_paths):  # type: ignore
     class TestBadLinePostProcessor(nunavut.postprocessors.LinePostProcessor):
-
         def __call__(self, line_and_lineend: typing.Tuple[str, str]) -> typing.Tuple[str, str]:
             return None  # type: ignore
 
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[TestBadLinePostProcessor()])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[TestBadLinePostProcessor()]
+    )
     with pytest.raises(ValueError):
         generator.generate_all(False, True)
 
 
 def test_trim_trailing_ws(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[nunavut.postprocessors.TrimTrailingWhitespace()])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace,
+        templates_dir=gen_paths.templates_dir,
+        post_processors=[nunavut.postprocessors.TrimTrailingWhitespace()],
+    )
     generator.generate_all(False, True)
     outfile = _test_common_post_condition(gen_paths, namespace)
 
@@ -294,10 +304,8 @@ def test_trim_trailing_ws(gen_paths):  # type: ignore
 
 
 def test_trim_trailing_ws_ln_config(gen_paths):  # type: ignore
-    namespace = _test_common_namespace(gen_paths,
-                                       additional_config={'trim_trailing_whitespace': 'True'})
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir)
+    namespace = _test_common_namespace(gen_paths, additional_config={"trim_trailing_whitespace": "True"})
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False, True)
     outfile = _test_common_post_condition(gen_paths, namespace)
 
@@ -306,89 +314,109 @@ def test_trim_trailing_ws_ln_config(gen_paths):  # type: ignore
 
 def test_limit_empty_lines(gen_paths):  # type: ignore
     namespace = _test_common_namespace(gen_paths)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[nunavut.postprocessors.LimitEmptyLines(0)])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[nunavut.postprocessors.LimitEmptyLines(0)]
+    )
     generator.generate_all(False, True)
     _assert_no_empty_lines(_test_common_post_condition(gen_paths, namespace))
 
 
 def test_limit_empty_lines_by_ln_config_cmd_line_none(gen_paths):  # type: ignore
-    namespace = _test_common_namespace(gen_paths,
-                                       additional_config={'limit_empty_lines': '0'})
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir)
+    namespace = _test_common_namespace(gen_paths, additional_config={"limit_empty_lines": "0"})
+    generator = nunavut.jinja.DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False, True)
 
     _assert_no_empty_lines(_test_common_post_condition(gen_paths, namespace))
 
 
 def test_limit_empty_lines_by_ln_config_cmd_line_less(gen_paths):  # type: ignore
-    namespace = _test_common_namespace(gen_paths,
-                                       additional_config={'limit_empty_lines': '1'})
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[nunavut.postprocessors.LimitEmptyLines(0)])
+    namespace = _test_common_namespace(gen_paths, additional_config={"limit_empty_lines": "1"})
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[nunavut.postprocessors.LimitEmptyLines(0)]
+    )
     generator.generate_all(False, True)
 
     _assert_no_empty_lines(_test_common_post_condition(gen_paths, namespace))
 
 
 def test_pp_trim_trailing_whitespace(gen_paths, run_nnvg):  # type: ignore
-    """ Verify the --pp-trim-trailing-whitespace argument of nnvg.
-    """
-    outfile = gen_paths.out_dir /\
-        pathlib.Path('uavcan') /\
-        pathlib.Path('test') /\
-        pathlib.Path('TestType_0_2').with_suffix('.json')
+    """Verify the --pp-trim-trailing-whitespace argument of nnvg."""
+    outfile = (
+        gen_paths.out_dir
+        / pathlib.Path("uavcan")
+        / pathlib.Path("test")
+        / pathlib.Path("TestType_0_2").with_suffix(".json")
+    )
 
-    nnvg_cmd_0 = ['--templates', str(gen_paths.templates_dir),
-                  '-O', str(gen_paths.out_dir),
-                  '-e', '.json',
-                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_cmd_0 = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-Xlang",
+        "-l",
+        "js",
+        "-e",
+        ".json",
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_cmd_0)
 
     lines_w_trailing = 0
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         for line in json_file:
-            if re.search(r' +$', line) is not None:
+            if re.search(r" +$", line) is not None:
                 lines_w_trailing += 1
 
     assert lines_w_trailing > 0
 
-    nnvg_cmd_1 = ['--templates', str(gen_paths.templates_dir),
-                  '-O', str(gen_paths.out_dir),
-                  '-e', '.json',
-                  '--pp-trim-trailing-whitespace',
-                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_cmd_1 = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        "--pp-trim-trailing-whitespace",
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_cmd_1)
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         for line in json_file:
-            assert re.search(r' +$', line) is None
+            assert re.search(r" +$", line) is None
 
 
 def test_pp_max_emptylines(gen_paths, run_nnvg):  # type: ignore
-    """ Verify the --pp-max-emptylines argument of nnvg.
-    """
-    outfile = gen_paths.out_dir /\
-        pathlib.Path('uavcan') /\
-        pathlib.Path('test') /\
-        pathlib.Path('TestType_0_2').with_suffix('.json')
+    """Verify the --pp-max-emptylines argument of nnvg."""
+    outfile = (
+        gen_paths.out_dir
+        / pathlib.Path("uavcan")
+        / pathlib.Path("test")
+        / pathlib.Path("TestType_0_2").with_suffix(".json")
+    )
 
-    nnvg_cmd_0 = ['--templates', str(gen_paths.templates_dir),
-                  '-O', str(gen_paths.out_dir),
-                  '-e', '.json',
-                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_cmd_0 = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        "-l",
+        "js",
+        "-Xlang",
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_cmd_0)
 
     found_empty_line = False
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         for line in json_file:
-            line_end_match = re.search(r'\n|\r\n', line)
+            line_end_match = re.search(r"\n|\r\n", line)
             if line_end_match is not None and len(line) == line_end_match.end() - line_end_match.start():
                 found_empty_line = True
                 break
@@ -398,18 +426,27 @@ def test_pp_max_emptylines(gen_paths, run_nnvg):  # type: ignore
 
     assert found_empty_line
 
-    nnvg_cmd_1 = ['--templates', str(gen_paths.templates_dir),
-                  '-O', str(gen_paths.out_dir),
-                  '-e', '.json',
-                  '--pp-max-emptylines', '0',
-                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_cmd_1 = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        "-l",
+        "js",
+        "-Xlang",
+        "--pp-max-emptylines",
+        "0",
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_cmd_1)
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         for line in json_file:
             for line in json_file:
-                line_end_match = re.search(r'\n|\r\n', line)
+                line_end_match = re.search(r"\n|\r\n", line)
                 if line_end_match is not None:
                     assert len(line) > line_end_match.end() - line_end_match.start()
                 else:
@@ -421,21 +458,21 @@ def test_external_edit_in_place(gen_paths):  # type: ignore
     Test that ExternalProgramEditInPlace is invoked as expected
     """
     namespace = _test_common_namespace(gen_paths)
-    ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
+    ext_program = gen_paths.test_dir / pathlib.Path("ext_program.py")
     edit_in_place = nunavut.postprocessors.ExternalProgramEditInPlace([str(ext_program)])
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[edit_in_place])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[edit_in_place]
+    )
     generator.generate_all(False, True)
 
     outfile = gen_paths.find_outfile_in_namespace("uavcan.test.TestType", namespace)
     assert outfile is not None
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['ext'] == 'changed'
+    assert json_blob["ext"] == "changed"
 
 
 def test_external_edit_in_place_fail(gen_paths):  # type: ignore
@@ -443,55 +480,75 @@ def test_external_edit_in_place_fail(gen_paths):  # type: ignore
     Test that ExternalProgramEditInPlace handles error as expected.
     """
     namespace = _test_common_namespace(gen_paths)
-    ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
-    simulated_error_args = [str(ext_program), '--simulate-error']
+    ext_program = gen_paths.test_dir / pathlib.Path("ext_program.py")
+    simulated_error_args = [str(ext_program), "--simulate-error"]
     edit_in_place_checking = nunavut.postprocessors.ExternalProgramEditInPlace(simulated_error_args)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[edit_in_place_checking])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[edit_in_place_checking]
+    )
     with pytest.raises(subprocess.CalledProcessError):
         generator.generate_all(False, True)
     edit_in_place_not_checking = nunavut.postprocessors.ExternalProgramEditInPlace(simulated_error_args, check=False)
-    generator = nunavut.jinja.DSDLCodeGenerator(namespace,
-                                                templates_dir=gen_paths.templates_dir,
-                                                post_processors=[edit_in_place_not_checking])
+    generator = nunavut.jinja.DSDLCodeGenerator(
+        namespace, templates_dir=gen_paths.templates_dir, post_processors=[edit_in_place_not_checking]
+    )
     generator.generate_all(False, True)
 
 
 def test_pp_run_program(gen_paths, run_nnvg):  # type: ignore
-    outfile = gen_paths.out_dir /\
-        pathlib.Path('uavcan') /\
-        pathlib.Path('test') /\
-        pathlib.Path('TestType_0_2').with_suffix('.json')
+    outfile = (
+        gen_paths.out_dir
+        / pathlib.Path("uavcan")
+        / pathlib.Path("test")
+        / pathlib.Path("TestType_0_2").with_suffix(".json")
+    )
 
-    ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
+    ext_program = gen_paths.test_dir / pathlib.Path("ext_program.py")
 
-    nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
-                  '-O', str(gen_paths.out_dir),
-                  '-e', '.json',
-                  '--pp-run-program', str(ext_program),
-                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_args0 = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        "-l",
+        "js",
+        "-Xlang",
+        "--pp-run-program",
+        str(ext_program),
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     run_nnvg(gen_paths, nnvg_args0)
 
-    with open(str(outfile), 'r') as json_file:
+    with open(str(outfile), "r") as json_file:
         json_blob = json.load(json_file)
 
     assert json_blob is not None
-    assert json_blob['ext'] == 'changed'
+    assert json_blob["ext"] == "changed"
 
     assert pathlib.Path(outfile).stat().st_mode & 0o777 == 0o444
 
 
 def test_pp_run_program_w_arg(gen_paths, run_nnvg):  # type: ignore
-    ext_program = gen_paths.test_dir / pathlib.Path('ext_program.py')
+    ext_program = gen_paths.test_dir / pathlib.Path("ext_program.py")
 
-    nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
-                  '-O', str(gen_paths.out_dir),
-                  '-e', '.json',
-                  '--pp-run-program', str(ext_program),
-                  '--pp-run-program-arg=--simulate-error',
-                  str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
+    nnvg_args0 = [
+        "--templates",
+        str(gen_paths.templates_dir),
+        "-O",
+        str(gen_paths.out_dir),
+        "-e",
+        ".json",
+        "-l",
+        "js",
+        "-Xlang",
+        "--pp-run-program",
+        str(ext_program),
+        "--pp-run-program-arg=--simulate-error",
+        str(gen_paths.dsdl_dir / pathlib.Path("uavcan")),
+    ]
 
     with pytest.raises(subprocess.CalledProcessError):
         run_nnvg(gen_paths, nnvg_args0, raise_called_process_error=True)

--- a/test/gentest_postprocessors/test_whitespace_ctrl.py
+++ b/test/gentest_postprocessors/test_whitespace_ctrl.py
@@ -6,8 +6,6 @@
 import pathlib
 import typing
 
-import pytest
-
 
 def get_path_to_TestType_0_2(gen_paths: typing.Any) -> pathlib.Path:
     uavcan_dir = pathlib.Path(gen_paths.out_dir / pathlib.Path('uavcan'))
@@ -22,6 +20,8 @@ def test_no_trim_blocks(gen_paths: typing.Any, run_nnvg: typing.Callable) -> Non
     nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
                   '-O', str(gen_paths.out_dir),
                   '-e', '.json',
+                  '-l', 'js',
+                  '-Xlang',
                   str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
     run_nnvg(gen_paths, nnvg_args0)
@@ -40,6 +40,8 @@ def test_trim_blocks(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None:
     nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
                   '-O', str(gen_paths.out_dir),
                   '-e', '.json',
+                  '-l', 'js',
+                  '-Xlang',
                   '--trim-blocks',
                   str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
@@ -59,6 +61,8 @@ def test_no_lstrip_blocks(gen_paths: typing.Any, run_nnvg: typing.Callable) -> N
     nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
                   '-O', str(gen_paths.out_dir),
                   '-e', '.json',
+                  '-l', 'js',
+                  '-Xlang',
                   str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 
     run_nnvg(gen_paths, nnvg_args0)
@@ -77,6 +81,8 @@ def test_lstrip_blocks(gen_paths: typing.Any, run_nnvg: typing.Callable) -> None
     nnvg_args0 = ['--templates', str(gen_paths.templates_dir),
                   '-O', str(gen_paths.out_dir),
                   '-e', '.json',
+                  '-l', 'js',
+                  '-Xlang',
                   '--lstrip-blocks',
                   str(gen_paths.dsdl_dir / pathlib.Path("uavcan"))]
 

--- a/test/gentest_serialization/test_serialization.py
+++ b/test/gentest_serialization/test_serialization.py
@@ -12,55 +12,68 @@ from pathlib import Path
 import pytest
 
 from nunavut import generate_types
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder
 
 
-@pytest.mark.parametrize('lang_key', ['cpp', 'c'])
+@pytest.mark.parametrize("lang_key", ["cpp", "c"])
 def test_support_headers(gen_paths, lang_key):  # type: ignore
     """
     Test that the support headers are generated/copied.
     """
-    ln = LanguageContext(lang_key).get_target_language()
+    ln = (
+        LanguageContextBuilder(include_experimental_languages=(lang_key == "cpp"))
+        .set_target_language(lang_key)
+        .create()
+        .get_target_language()
+    )
     assert ln is not None
-    expected_header = gen_paths.out_dir / \
-        Path('nunavut') / \
-        Path('support') / \
-        Path('serialization').with_suffix(ln.extension)
+    expected_header = (
+        gen_paths.out_dir / Path("nunavut") / Path("support") / Path("serialization").with_suffix(ln.extension)
+    )
     root_namespace_dir = gen_paths.dsdl_dir / Path("basic")
-    generate_types(lang_key,
-                   root_namespace_dir,
-                   gen_paths.out_dir,
-                   omit_serialization_support=False,
-                   allow_unregulated_fixed_port_id=True)
+    generate_types(
+        lang_key,
+        root_namespace_dir,
+        gen_paths.out_dir,
+        omit_serialization_support=False,
+        allow_unregulated_fixed_port_id=True,
+        include_experimental_languages=(lang_key == "cpp"),
+    )
 
     assert expected_header.exists()
 
 
-@pytest.mark.parametrize('lang_key', ['cpp', 'c'])
+@pytest.mark.parametrize("lang_key", ["cpp", "c"])
 def test_gen_with_serialization_basic(gen_paths, lang_key):  # type: ignore
     """
     Sanity test. See test_gen_with_serialization_complex for details.
     """
-    basic_types = gen_paths.dsdl_dir / pathlib.Path('basic')
-    generate_types(lang_key,
-                   basic_types,
-                   gen_paths.out_dir,
-                   omit_serialization_support=False,
-                   allow_unregulated_fixed_port_id=True)
+    basic_types = gen_paths.dsdl_dir / pathlib.Path("basic")
+    generate_types(
+        lang_key,
+        basic_types,
+        gen_paths.out_dir,
+        omit_serialization_support=False,
+        allow_unregulated_fixed_port_id=True,
+        include_experimental_languages=(lang_key == "cpp"),
+    )
 
 
-@pytest.mark.parametrize('lang_key', ['cpp', 'c'])
+@pytest.mark.parametrize("lang_key", ["cpp", "c"])
 def test_gen_with_serialization_complex(gen_paths, lang_key):  # type: ignore
     """
     Sanity test that generates some types with serialization code. We need the verification tests
     to do full tests on the code that was generated (i.e. you need a C compiler and C unit tests to
     verify the generated C serialization routines).
     """
-    basic_types = gen_paths.dsdl_dir / pathlib.Path('basic')
-    complex_types = gen_paths.dsdl_dir / pathlib.Path('complex')
-    generate_types(lang_key,
-                   complex_types,
-                   gen_paths.out_dir,
-                   lookup_directories=[str(basic_types)],
-                   omit_serialization_support=False,
-                   allow_unregulated_fixed_port_id=True)
+    basic_types = gen_paths.dsdl_dir / pathlib.Path("basic")
+    complex_types = gen_paths.dsdl_dir / pathlib.Path("complex")
+    generate_types(
+        lang_key,
+        complex_types,
+        gen_paths.out_dir,
+        lookup_directories=[str(basic_types)],
+        omit_serialization_support=False,
+        allow_unregulated_fixed_port_id=True,
+        include_experimental_languages=(lang_key == "cpp"),
+    )

--- a/test/gentest_tests/test_tests.py
+++ b/test/gentest_tests/test_tests.py
@@ -10,7 +10,7 @@ from pydsdl import read_namespace
 
 from nunavut import build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import LanguageContext
+from nunavut.lang import LanguageContextBuilder
 
 
 def test_instance_tests(gen_paths):  # type: ignore
@@ -20,7 +20,7 @@ def test_instance_tests(gen_paths):  # type: ignore
     """
     root_namespace_dir = gen_paths.dsdl_dir / Path("buncho")
     type_map = read_namespace(str(root_namespace_dir), [])
-    language_context = LanguageContext('js')
+    language_context = LanguageContextBuilder(include_experimental_languages=True).set_target_language('js').create()
     namespace = build_namespace_tree(type_map,
                                      root_namespace_dir,
                                      gen_paths.out_dir,

--- a/test/gentest_uses/test_uses.py
+++ b/test/gentest_uses/test_uses.py
@@ -8,21 +8,26 @@ from pathlib import Path
 
 import pytest
 from nunavut import build_namespace_tree
+from nunavut.lang import LanguageContextBuilder, Language
 from nunavut.jinja import DSDLCodeGenerator
 from pydsdl import read_namespace
-from nunavut import generate_types
 
 
 @pytest.mark.parametrize("std,expect_uses_variant", [("c++14", False), ("c++17", True)])
-def test_ifuses(gen_paths, configurable_language_context_factory, std, expect_uses_variant):  # type: ignore
+def test_ifuses(gen_paths, std, expect_uses_variant):  # type: ignore
     """
     Verifies that instance tests are added for pydsdl.SerializableType and
     all of its subclasses.
     """
-    config_overrides = {"nunavut.lang.cpp": {"options": {"std": std}}}
+    options = {"std": std}
     root_namespace_dir = gen_paths.dsdl_dir / Path("denada")
     type_map = read_namespace(str(root_namespace_dir), [])
-    language_context = configurable_language_context_factory(config_overrides, "cpp")
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True)
+        .set_target_language("cpp")
+        .set_target_language_configuration_override(Language.WKCV_LANGUAGE_OPTIONS, options)
+        .create()
+    )
     namespace = build_namespace_tree(type_map, root_namespace_dir, gen_paths.out_dir, language_context)
     generator = DSDLCodeGenerator(namespace, templates_dir=gen_paths.templates_dir)
     generator.generate_all(False)

--- a/test/gentest_versions/test_versions.py
+++ b/test/gentest_versions/test_versions.py
@@ -12,56 +12,50 @@ import re
 
 from nunavut import build_namespace_tree
 from nunavut.jinja import DSDLCodeGenerator
-from nunavut.lang import LanguageContext
+from nunavut.lang import Language, LanguageContextBuilder
 
 
 include_pattern_map = (
-    ['cpp', 'VIRUSES_COVID_{major}_{minor}_HPP_INCLUDED'],
-    ['c', 'VIRUSES_COVID_{major}_{minor}_INCLUDED_'],  # Due to the limitations of C, collisions are likely, hence '_'
+    ["cpp", "VIRUSES_COVID_{major}_{minor}_HPP_INCLUDED"],
+    ["c", "VIRUSES_COVID_{major}_{minor}_INCLUDED_"],  # Due to the limitations of C, collisions are likely, hence '_'
 )
 
 
-@pytest.mark.parametrize('lang_key,include_format', include_pattern_map)
+@pytest.mark.parametrize("lang_key,include_format", include_pattern_map)
 def test_issue_136(gen_paths, lang_key: str, include_format: str):  # type: ignore
     """
     Generates a type that has two different versions using the built-in language support and verifies
     that the header include guards include the type version. This verifies fix #136 has not
     regressed.
     """
-    covid_versions = [
-        pydsdl.Version(1, 9),
-        pydsdl.Version(1, 10)
-    ]
+    covid_versions = [pydsdl.Version(1, 9), pydsdl.Version(1, 10)]
     root_namespace = str(gen_paths.dsdl_dir / Path("viruses"))
     compound_types = pydsdl.read_namespace(root_namespace, [], allow_unregulated_fixed_port_id=True)
-    language_context = LanguageContext(lang_key, omit_serialization_support_for_target=True)
-    namespace = build_namespace_tree(compound_types,
-                                     root_namespace,
-                                     gen_paths.out_dir,
-                                     language_context)
+    language_context = (
+        LanguageContextBuilder(include_experimental_languages=True).set_target_language(lang_key).create()
+    )
+    namespace = build_namespace_tree(compound_types, root_namespace, gen_paths.out_dir, language_context)
     generator = DSDLCodeGenerator(namespace)
-    generator.generate_all(False)
+    generator.generate_all(omit_serialization_support=True)
 
     for covid_version in covid_versions:
 
-        include_guard_start = re.compile(r'#ifndef {}\b'.format(
-            include_format.format(major=covid_version.major,
-                                  minor=covid_version.minor)
-        ))
+        include_guard_start = re.compile(
+            r"#ifndef {}\b".format(include_format.format(major=covid_version.major, minor=covid_version.minor))
+        )
 
-        include_guard_def = re.compile(r'#define {}\b'.format(
-            include_format.format(major=covid_version.major,
-                                  minor=covid_version.minor)
-        ))
+        include_guard_def = re.compile(
+            r"#define {}\b".format(include_format.format(major=covid_version.major, minor=covid_version.minor))
+        )
 
         # Now read back in and verify
         outfile = gen_paths.find_outfile_in_namespace("viruses.covid", namespace, type_version=covid_version)
 
-        assert (outfile is not None)
+        assert outfile is not None
 
         found_open_line = 0
         found_def_line = 0
-        with open(str(outfile), 'r') as header_file:
+        with open(str(outfile), "r") as header_file:
             line_no = 1
             for line in header_file:
                 if include_guard_start.match(line):
@@ -70,5 +64,5 @@ def test_issue_136(gen_paths, lang_key: str, include_format: str):  # type: igno
                     found_def_line = line_no
                     break
                 line_no += 1
-        assert (found_open_line > 0)
-        assert (found_def_line > found_open_line)
+        assert found_open_line > 0
+        assert found_def_line > found_open_line

--- a/tox.ini
+++ b/tox.ini
@@ -197,7 +197,7 @@ commands =
 
 
 [testenv:lint]
-basepython = python3.9
+basepython = python3.10
 deps =
      {[dev]deps}
     black


### PR DESCRIPTION
Nunavut V2 is not a huge change from v1 but it the Python APIs are different enough to warrent the semantic, major revision bump.

The core difference is a refactor of the Language objects to fully support the properties.yaml schema and allow overrides to be provided to nnvg.

A follow-up to this change, before v2 is published, will be a refactor of the internal package and module names to improve encapsulation and to be more consistent with the style of other OpenCyphal python projects.