### PR TITLE
Add guard to try / catch inside variable length arrays, allow compilation with -fno-exceptions

### DIFF
--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -468,7 +468,7 @@ public:
             (void) e;
         }
 #else
-            new_data = alloc_.allocate(no_shrink_capacity);
+        new_data = alloc_.allocate(no_shrink_capacity);
 #endif
 
         if (new_data != nullptr)
@@ -675,7 +675,6 @@ private:
         // opportunity for reusing previously freed memory comes when increasing to 19 from 13 since E(n-1) == 21.
         const std::size_t new_capacity = capacity_before + ((half_capacity <= 1) ? 2 : half_capacity);
 
-
         if (new_capacity > MaxSize)
         {
             reserve(MaxSize);
@@ -696,7 +695,6 @@ private:
         {
             return true;
         }
-
     }
 
     template <typename U>

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -456,6 +456,8 @@ public:
         const std::size_t no_shrink_capacity = (clamped_capacity > size_) ? clamped_capacity : size_;
 
         T* new_data = nullptr;
+
+#if __cpp_exceptions
         try
         {
             new_data = alloc_.allocate(no_shrink_capacity);
@@ -465,6 +467,9 @@ public:
             // null by this class.
             (void) e;
         }
+#else
+            new_data = alloc_.allocate(no_shrink_capacity);
+#endif
 
         if (new_data != nullptr)
         {


### PR DESCRIPTION
Hello, 

That's it. Use **-fno-exceptions** with the C++ generated variable_length_array.hpp header. 
I need this flag as it get back a lot of heap space.

Maybe a better logic could be implemented like just returning 0 if the vector is already full ? 

