### PR TITLE
Add bool specialization for VariableLengthArray; fix AUTOSAR compliance issues; fix GTest integration

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -265,6 +265,8 @@ In the list of targets that the :code:`cmake --build . --target help` command li
 will be prefixed with :code:`test_` and the psedo-target that also executes the test will be prefixed with
 :code:`run_test_`. You should avoid the :code:`_with_lcov` when you are manually building tests.
 
+To obtain coverage information for the verification suite (not the Python code),
+build the `cov_all` target and inspect the output under the `coverage` directory.
 
 cmake build options
 ------------------------------------------------

--- a/src/nunavut/_version.py
+++ b/src/nunavut/_version.py
@@ -8,7 +8,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __license__ = "MIT"
 __author__ = "OpenCyphal"
 __copyright__ = "Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. Copyright (c) 2022 OpenCyphal."

--- a/src/nunavut/jinja/__init__.py
+++ b/src/nunavut/jinja/__init__.py
@@ -159,7 +159,6 @@ class CodeGenerator(nunavut._generators.AbstractGenerator):
         package_name_for_templates: typing.Optional[str] = None,
         search_policy: ResourceSearchPolicy = ResourceSearchPolicy.FIND_ALL,
     ):
-
         super().__init__(namespace, generate_namespace_types)
 
         if templates_dir is not None and not isinstance(templates_dir, list):
@@ -668,7 +667,6 @@ class DSDLCodeGenerator(CodeGenerator):
     # +-----------------------------------------------------------------------+
 
     def __init__(self, namespace: nunavut.Namespace, **kwargs: typing.Any):
-
         # set the search policy so we ignore the internal templates iff a filesystem
         # path is provided to the generator.
         super().__init__(namespace, search_policy=ResourceSearchPolicy.FIND_FIRST, **kwargs)
@@ -688,7 +686,7 @@ class DSDLCodeGenerator(CodeGenerator):
             *self.language_context.get_target_language().get_support_module(), is_dryrun, omit_serialization_support
         )
         provider = self.namespace.get_all_types if self.generate_namespace_types else self.namespace.get_all_datatypes
-        for (parsed_type, output_path) in provider():
+        for parsed_type, output_path in provider():
             logger.info("Generating: %s", parsed_type)
             generated.append(self._generate_type(parsed_type, output_path, is_dryrun, allow_overwrite))
         return generated
@@ -785,7 +783,6 @@ class SupportGenerator(CodeGenerator):
     """
 
     def __init__(self, namespace: nunavut.Namespace, **kwargs: typing.Any):
-
         super().__init__(namespace, builtin_template_path="support", **kwargs)
 
         target_language = self.language_context.get_target_language()
@@ -867,7 +864,6 @@ class SupportGenerator(CodeGenerator):
         line_pps: typing.List["nunavut._postprocessors.LinePostProcessor"],
         file_pps: typing.List["nunavut._postprocessors.FilePostProcessor"],
     ) -> pathlib.Path:
-
         if not is_dryrun:
             self._handle_overwrite(target, allow_overwrite)
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/src/nunavut/jinja/environment.py
+++ b/src/nunavut/jinja/environment.py
@@ -274,7 +274,6 @@ class CodeGenEnvironment(Environment):
         is_dryrun: bool = False,
         omit_serialization_support: bool = False,
     ) -> None:
-
         nunavut_namespace = self.nunavut_global
 
         setattr(
@@ -498,7 +497,6 @@ class CodeGenEnvironment(Environment):
             )
 
     def _update_language_support(self, lctx: LanguageContext) -> None:
-
         supported_languages = lctx.get_supported_languages()
         target_language = lctx.get_target_language()
         ln_globals = self.globals["ln"]

--- a/src/nunavut/jinja/extensions.py
+++ b/src/nunavut/jinja/extensions.py
@@ -212,7 +212,6 @@ class UseQuery(Extension):
         return result
 
     def _use_query_common(self, uses_query_name: str, lineno: int, name: str, filename: str) -> bool:
-
         target_language = self.environment.target_language
 
         if uses_query_name is None:

--- a/src/nunavut/lang/__init__.py
+++ b/src/nunavut/lang/__init__.py
@@ -356,7 +356,6 @@ class LanguageContextBuilder:
         return languages
 
     def _resolve_target_language(self, explicit_value: typing.Optional[str]) -> str:
-
         if explicit_value is not None:
             return explicit_value
 

--- a/src/nunavut/lang/_common.py
+++ b/src/nunavut/lang/_common.py
@@ -393,7 +393,6 @@ class TokenEncoder:
         return stropped
 
     def _strop_by_pattern(self, token: str, token_type: str, dry_run: bool) -> str:
-
         stropped = token
 
         reserved_pattern_rules = self._reserved_token_patterns_by_type[token_type]
@@ -439,7 +438,6 @@ class TokenEncoder:
 
     @functools.lru_cache(maxsize=1024)
     def strop(self, token: str, token_type: str = "any") -> str:  # noqa: C901
-
         token_type_lower = token_type.lower()
         if token_type_lower == "all":
             raise ValueError(

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -473,7 +473,7 @@ public:
                 const uint8_t in = static_cast<uint8_t>(static_cast<uint8_t>(data_[src_off / 8U] >> src_mod) << dst_mod) & 0xFFU;  // NOSONAR
                 // Intentional violation of MISRA: indexing on a pointer.
                 // This simplifies the implementation greatly and avoids pointer arithmetics.
-                const uint8_t a = dst.data_[dst_off / 8U] & (static_cast<uint8_t>((~mask) & 0xFFU));  // NOSONAR
+                const uint8_t a = dst.data_[dst_off / 8U] & (static_cast<uint8_t>(static_cast<uint8_t>(~mask) & 0xFFU));  // NOSONAR
                 const uint8_t b = in & mask;
                 // Intentional violation of MISRA: indexing on a pointer.
                 // This simplifies the implementation greatly and avoids pointer arithmetics.

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -90,7 +90,7 @@ public:
     ///
     using value_type = T;
 
-    VariableLengthArray() noexcept(std::is_nothrow_constructible<allocator_type>::value)
+    constexpr VariableLengthArray() noexcept(std::is_nothrow_constructible<allocator_type>::value)
         : data_(nullptr)
         , capacity_(0)
         , size_(0)
@@ -1053,7 +1053,7 @@ public:
     using iterator       = IteratorImpl<VariableLengthArray>;
     using const_iterator = IteratorImpl<const VariableLengthArray>;
 
-    VariableLengthArray() noexcept
+    constexpr VariableLengthArray() noexcept
         : data_(nullptr)
         , capacity_(0)
         , size_(0)

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -928,6 +928,7 @@ private:
         using difference_type   = typename A::difference_type;
         using reference         = ReferenceImpl<A>;
         using const_reference   = ReferenceImpl<const A>;
+        using pointer           = void;
 
         IteratorImpl() noexcept = default;
 
@@ -956,30 +957,38 @@ private:
 
         IteratorImpl& operator+=(const difference_type n)
         {
-            index_ += n;
+            index_ = static_cast<size_type>(static_cast<difference_type>(index_) + n);
             return *this;
         }
         IteratorImpl& operator-=(const difference_type n)
         {
-            index_ -= n;
+            index_ = static_cast<size_type>(static_cast<difference_type>(index_) - n);
             return *this;
         }
         IteratorImpl operator+(const difference_type n) const
         {
-            return IteratorImpl(*array_, index_ + n);
+            return IteratorImpl(*array_, static_cast<size_type>(static_cast<difference_type>(index_) + n));
         }
         IteratorImpl operator-(const difference_type n) const
         {
-            return IteratorImpl(*array_, index_ - n);
+            return IteratorImpl(*array_, static_cast<size_type>(static_cast<difference_type>(index_) - n));
         }
         difference_type operator-(const IteratorImpl& other) const
         {
             return static_cast<difference_type>(index_) - static_cast<difference_type>(other.index_);
         }
 
-        reference operator*() const
+        reference operator*()
         {
-            return array_->operator[](index_);
+            return this->operator[](0);
+        }
+        const_reference operator*() const
+        {
+            return this->operator[](0);
+        }
+        reference operator[](const difference_type n)
+        {
+            return array_->operator[](static_cast<size_type>(static_cast<difference_type>(index_) + n));
         }
         const_reference operator[](const difference_type n) const
         {
@@ -1268,25 +1277,29 @@ public:
     /// Safe, const access to an element. Throws std::out_of_range if {@code pos} is >= {@code size}.
     /// The returned reference is valid while this object is unless {@code reserve} or {@code shrink_to_fit} is called.
     ///
-    constexpr const_reference at(const size_type pos) const noexcept
+    constexpr const_reference at(const size_type pos) const
     {
         if (pos >= size_)
         {
 #if __cpp_exceptions
             throw std::out_of_range("VariableLengthArray::at");
+#else
+            std::abort();
 #endif
         }
-        return const_reference(*this, pos);
+        return this->operator[](pos);
     }
-    constexpr reference at(const size_type pos) noexcept
+    constexpr reference at(const size_type pos)
     {
         if (pos >= size_)
         {
 #if __cpp_exceptions
             throw std::out_of_range("VariableLengthArray::at");
+#else
+            std::abort();
 #endif
         }
-        return reference(*this, pos);
+        return this->operator[](pos);
     }
 
     ///

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -1565,6 +1565,10 @@ private:
     allocator_type alloc_;
 };
 
+// required till C++ 17. Redundant but allowed after that.
+template <std::size_t MaxSize, typename Allocator>
+const std::size_t VariableLengthArray<bool, MaxSize, Allocator>::type_max_size;
+
 }  // namespace support
 }  // namespace nunavut
 

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+// Copyright (C) 2014 Pavel Kirienko <pavel@opencyphal.org>
 // Copyright (C) 2021  OpenCyphal Development Team  <opencyphal.org>
 // This software is distributed under the terms of the MIT License.
 //

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -1249,7 +1249,7 @@ public:
             const auto idx = split_index(pos);
             if (value)
             {
-                data_[idx.first] = data_[idx.first] | (1U << idx.second);
+                data_[idx.first] = static_cast<Storage>(data_[idx.first] | (1U << idx.second));
             }
             else
             {
@@ -1547,7 +1547,8 @@ private:
     {
         if (size_ < capacity_)
         {
-            reference(*this, size_++) = value;
+            const size_type index = size_++;
+            set(index, value);
             return true;
         }
         return false;

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -877,6 +877,10 @@ private:
     class ReferenceImpl final
     {
     public:
+        ReferenceImpl(const ReferenceImpl&) = default;
+        ReferenceImpl(ReferenceImpl&&)      = default;
+        ~ReferenceImpl()                    = default;
+
         ReferenceImpl& operator=(const bool x)
         {
             array_.set(index_, x);
@@ -884,8 +888,11 @@ private:
         }
         ReferenceImpl& operator=(const ReferenceImpl& x)
         {
-            array_.set(index_, x);
-            return *this;
+            return this->operator=(static_cast<bool>(x));
+        }
+        ReferenceImpl& operator=(ReferenceImpl&& x)
+        {
+            return this->operator=(static_cast<bool>(x));
         }
 
         bool operator~() const

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -910,6 +910,11 @@ public:
             return !((*this) == rhs);
         }
 
+        void flip()
+        {
+            array_.set(index_, !array_.test(index_));
+        }
+
     private:
         friend class VariableLengthArray;
 

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -115,13 +115,13 @@ public:
 
     template <class InputIt>
     constexpr VariableLengthArray(
-        InputIt           first,
-        InputIt           last,
-        const std::size_t length,
-        const allocator_type&  alloc =
+        InputIt               first,
+        InputIt               last,
+        const std::size_t     length,
+        const allocator_type& alloc =
             allocator_type()) noexcept(noexcept(VariableLengthArray<T, MaxSize, Allocator>().reserve(1)) &&
-                                  std::is_nothrow_copy_constructible<allocator_type>::value &&
-                                  std::is_nothrow_copy_constructible<T>::value)
+                                       std::is_nothrow_copy_constructible<allocator_type>::value &&
+                                       std::is_nothrow_copy_constructible<T>::value)
         : data_(nullptr)
         , capacity_(0)
         , size_(0)
@@ -185,10 +185,8 @@ public:
     }
 
     VariableLengthArray& operator=(VariableLengthArray&& rhs) noexcept(
-        noexcept(VariableLengthArray<T, MaxSize, Allocator>::template fast_deallocate<T>(nullptr,
-                                                                                         0,
-                                                                                         0,
-                                                                                         std::declval<allocator_type&>())) &&
+        noexcept(VariableLengthArray<T, MaxSize, Allocator>::template fast_deallocate<
+                 T>(nullptr, 0, 0, std::declval<allocator_type&>())) &&
         std::is_nothrow_move_assignable<allocator_type>::value)
     {
         fast_deallocate(data_, size_, capacity_, alloc_);
@@ -207,11 +205,8 @@ public:
         return *this;
     }
 
-    ~VariableLengthArray() noexcept(
-        noexcept(VariableLengthArray<T, MaxSize, Allocator>::template fast_deallocate<T>(nullptr,
-                                                                                         0,
-                                                                                         0,
-                                                                                         std::declval<allocator_type&>())))
+    ~VariableLengthArray() noexcept(noexcept(VariableLengthArray<T, MaxSize, Allocator>::template fast_deallocate<
+                                             T>(nullptr, 0, 0, std::declval<allocator_type&>())))
     {
         fast_deallocate(data_, size_, capacity_, alloc_);
     }
@@ -519,11 +514,15 @@ public:
         // Allocate only enough to store what we have.
         T* minimized_data = nullptr;
 #if __cpp_exceptions
-        try {
+        try
+        {
 #endif
-        minimized_data = alloc_.allocate(size_ * sizeof(T));
+            minimized_data = alloc_.allocate(size_ * sizeof(T));
 #if __cpp_exceptions
-        } catch (const std::bad_alloc& e) { (void) e; }
+        } catch (const std::bad_alloc& e)
+        {
+            (void) e;
+        }
 #endif
 
         if (minimized_data == nullptr)
@@ -766,7 +765,7 @@ private:
     static constexpr void fast_deallocate(U* const          src,
                                           const std::size_t src_size_count,
                                           const std::size_t src_capacity_count,
-                                          allocator_type&        alloc,
+                                          allocator_type&   alloc,
                                           typename std::enable_if<std::is_trivially_destructible<U>::value>::type* =
                                               nullptr) noexcept(noexcept(allocator_type().deallocate(nullptr, 0)))
     {
@@ -782,9 +781,10 @@ private:
         U* const          src,
         const std::size_t src_size_count,
         const std::size_t src_capacity_count,
-        allocator_type&        alloc,
+        allocator_type&   alloc,
         typename std::enable_if<!std::is_trivially_destructible<U>::value>::type* =
-            nullptr) noexcept(std::is_nothrow_destructible<U>::value&& noexcept(allocator_type().deallocate(nullptr, 0)))
+            nullptr) noexcept(std::is_nothrow_destructible<U>::value&& noexcept(allocator_type().deallocate(nullptr,
+                                                                                                            0)))
     {
         std::size_t dtor_iterator = src_size_count;
         while (dtor_iterator > 0)
@@ -799,11 +799,11 @@ private:
     ///
     template <typename U>
     static constexpr void move_and_free(
-        U* const    dst,
-        U* const    src,
-        std::size_t src_len_count,
-        std::size_t src_capacity_count,
-        allocator_type&  alloc,
+        U* const        dst,
+        U* const        src,
+        std::size_t     src_len_count,
+        std::size_t     src_capacity_count,
+        allocator_type& alloc,
         typename std::enable_if<std::is_fundamental<U>::value>::type* =
             nullptr) noexcept(noexcept(fast_deallocate<U>(nullptr, 0, 0, std::declval<allocator_type&>())))
     {
@@ -820,16 +820,19 @@ private:
     ///
     template <typename U>
     static constexpr void move_and_free(
-        U* const    dst,
-        U* const    src,
-        std::size_t src_len_count,
-        std::size_t src_capacity_count,
-        allocator_type&  alloc,
+        U* const        dst,
+        U* const        src,
+        std::size_t     src_len_count,
+        std::size_t     src_capacity_count,
+        allocator_type& alloc,
         typename std::enable_if<!std::is_fundamental<U>::value>::type* = nullptr,
         typename std::enable_if<std::is_move_constructible<U>::value || std::is_copy_constructible<U>::value>::type* =
             nullptr) noexcept((std::is_nothrow_move_constructible<U>::value ||
-                         std::is_nothrow_copy_constructible<
-                             U>::value) && noexcept(fast_deallocate<U>(nullptr, 0, 0, std::declval<allocator_type&>())))
+                               std::is_nothrow_copy_constructible<
+                                   U>::value) && noexcept(fast_deallocate<U>(nullptr,
+                                                                             0,
+                                                                             0,
+                                                                             std::declval<allocator_type&>())))
     {
         if (src_len_count > 0)
         {

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -856,7 +856,7 @@ template <typename T, std::size_t MaxSize, typename Allocator>
 const std::size_t VariableLengthArray<T, MaxSize, Allocator>::type_max_size;
 
 ///
-/// A memory-optimized specialization for bool storing CHAT_BIT bits per byte;
+/// A memory-optimized specialization for bool storing 8 bits per byte;
 /// the internal bit ordering follows the Cyphal DSDL specification.
 /// Some features are not supported.
 ///

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
+#include <cmath>  // For floating-point array comparison.
 #include <type_traits>
 #include <memory>
 #include <limits>

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <type_traits>
 #include <memory>
+#include <limits>
 #include <utility>
 #include <initializer_list>
 #if __cpp_exceptions

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -701,7 +701,7 @@ private:
     static constexpr bool internal_compare_element(
         const U& lhs,
         const U& rhs,
-        typename std::enable_if<!std::is_floating_point<U>::value>::type* = 0) noexcept
+        typename std::enable_if<!std::is_floating_point<U>::value>::type* = nullptr) noexcept
     {
         return (lhs == rhs);
     }
@@ -710,7 +710,7 @@ private:
     static constexpr bool internal_compare_element(
         const U& lhs,
         const U& rhs,
-        typename std::enable_if<std::is_floating_point<U>::value>::type* = 0) noexcept
+        typename std::enable_if<std::is_floating_point<U>::value>::type* = nullptr) noexcept
     {
         // From the C++ documentation for std::numeric_limits<T>::epsilon()
         // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
@@ -768,7 +768,7 @@ private:
                                           const std::size_t src_capacity_count,
                                           allocator_type&        alloc,
                                           typename std::enable_if<std::is_trivially_destructible<U>::value>::type* =
-                                              0) noexcept(noexcept(allocator_type().deallocate(nullptr, 0)))
+                                              nullptr) noexcept(noexcept(allocator_type().deallocate(nullptr, 0)))
     {
         (void) src_size_count;
         alloc.deallocate(src, src_capacity_count);
@@ -784,7 +784,7 @@ private:
         const std::size_t src_capacity_count,
         allocator_type&        alloc,
         typename std::enable_if<!std::is_trivially_destructible<U>::value>::type* =
-            0) noexcept(std::is_nothrow_destructible<U>::value&& noexcept(allocator_type().deallocate(nullptr, 0)))
+            nullptr) noexcept(std::is_nothrow_destructible<U>::value&& noexcept(allocator_type().deallocate(nullptr, 0)))
     {
         std::size_t dtor_iterator = src_size_count;
         while (dtor_iterator > 0)
@@ -805,7 +805,7 @@ private:
         std::size_t src_capacity_count,
         allocator_type&  alloc,
         typename std::enable_if<std::is_fundamental<U>::value>::type* =
-            0) noexcept(noexcept(fast_deallocate<U>(nullptr, 0, 0, std::declval<allocator_type&>())))
+            nullptr) noexcept(noexcept(fast_deallocate<U>(nullptr, 0, 0, std::declval<allocator_type&>())))
     {
         if (src_len_count > 0)
         {
@@ -825,9 +825,9 @@ private:
         std::size_t src_len_count,
         std::size_t src_capacity_count,
         allocator_type&  alloc,
-        typename std::enable_if<!std::is_fundamental<U>::value>::type* = 0,
+        typename std::enable_if<!std::is_fundamental<U>::value>::type* = nullptr,
         typename std::enable_if<std::is_move_constructible<U>::value || std::is_copy_constructible<U>::value>::type* =
-            0) noexcept((std::is_nothrow_move_constructible<U>::value ||
+            nullptr) noexcept((std::is_nothrow_move_constructible<U>::value ||
                          std::is_nothrow_copy_constructible<
                              U>::value) && noexcept(fast_deallocate<U>(nullptr, 0, 0, std::declval<allocator_type&>())))
     {

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -878,9 +878,9 @@ public:
     class reference final
     {
     public:
-        reference(const reference&) = default;
-        reference(reference&&)      = default;
-        ~reference()                = default;
+        reference(const reference&) noexcept = default;
+        reference(reference&&) noexcept      = default;
+        ~reference() noexcept                = default;
 
         reference& operator=(const bool x)
         {
@@ -948,48 +948,48 @@ private:
 
         IteratorImpl() noexcept = default;
 
-        IteratorImpl& operator++()
+        IteratorImpl& operator++() noexcept
         {
             ++index_;
             return *this;
         }
-        IteratorImpl operator++(int)
+        IteratorImpl operator++(int) noexcept
         {
             const IteratorImpl tmp(*this);
             ++index_;
             return tmp;
         }
-        IteratorImpl& operator--()
+        IteratorImpl& operator--() noexcept
         {
             --index_;
             return *this;
         }
-        IteratorImpl operator--(int)
+        IteratorImpl operator--(int) noexcept
         {
             IteratorImpl tmp(*this);
             --index_;
             return tmp;
         }
 
-        IteratorImpl& operator+=(const difference_type n)
+        IteratorImpl& operator+=(const difference_type n) noexcept
         {
             index_ = static_cast<size_type>(static_cast<difference_type>(index_) + n);
             return *this;
         }
-        IteratorImpl& operator-=(const difference_type n)
+        IteratorImpl& operator-=(const difference_type n) noexcept
         {
             index_ = static_cast<size_type>(static_cast<difference_type>(index_) - n);
             return *this;
         }
-        IteratorImpl operator+(const difference_type n) const
+        IteratorImpl operator+(const difference_type n) const noexcept
         {
             return IteratorImpl(*array_, static_cast<size_type>(static_cast<difference_type>(index_) + n));
         }
-        IteratorImpl operator-(const difference_type n) const
+        IteratorImpl operator-(const difference_type n) const noexcept
         {
             return IteratorImpl(*array_, static_cast<size_type>(static_cast<difference_type>(index_) - n));
         }
-        difference_type operator-(const IteratorImpl& other) const
+        difference_type operator-(const IteratorImpl& other) const noexcept
         {
             return static_cast<difference_type>(index_) - static_cast<difference_type>(other.index_);
         }
@@ -1020,27 +1020,27 @@ private:
             return array_->operator[](static_cast<size_type>(static_cast<difference_type>(index_) + n));
         }
 
-        bool operator==(const IteratorImpl& other) const
+        bool operator==(const IteratorImpl& other) const noexcept
         {
             return array_ == other.array_ && index_ == other.index_;
         }
-        bool operator!=(const IteratorImpl& other) const
+        bool operator!=(const IteratorImpl& other) const noexcept
         {
             return !((*this) == other);
         }
-        bool operator<(const IteratorImpl& other) const
+        bool operator<(const IteratorImpl& other) const noexcept
         {
             return index_ < other.index_;
         }
-        bool operator>(const IteratorImpl& other) const
+        bool operator>(const IteratorImpl& other) const noexcept
         {
             return index_ > other.index_;
         }
-        bool operator<=(const IteratorImpl& other) const
+        bool operator<=(const IteratorImpl& other) const noexcept
         {
             return index_ <= other.index_;
         }
-        bool operator>=(const IteratorImpl& other) const
+        bool operator>=(const IteratorImpl& other) const noexcept
         {
             return index_ >= other.index_;
         }

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -1402,7 +1402,6 @@ public:
                 move_and_free(new_data, data_, size_, capacity_, alloc_);
             }  // else the allocator was able to simply extend the reserved area for the same memory pointer.
             data_ = new_data;
-            assert(no_shrink_capacity <= type_max_size);
             capacity_ = no_shrink_capacity;
         }
         return capacity_;

--- a/src/nunavut/lang/cpp/templates/_fields_as_union.j2
+++ b/src/nunavut/lang/cpp/templates/_fields_as_union.j2
@@ -16,7 +16,7 @@
         } internal_union_value_;
 
     public:
-        static const constexpr std::size_t variant_npos = -1;
+        static const constexpr std::size_t variant_npos = std::numeric_limits<std::size_t>::max();
 
         VariantType()
             : tag_(0)

--- a/verification/cmake/modules/Findgtest.cmake
+++ b/verification/cmake/modules/Findgtest.cmake
@@ -12,8 +12,8 @@ else()
 endif()
 
 include_directories(
-    ${GOOGLETEST_SUBMODULE}/googletest/include
-    ${GOOGLETEST_SUBMODULE}/googlemock/include
+    SYSTEM ${GOOGLETEST_SUBMODULE}/googletest/include
+    SYSTEM ${GOOGLETEST_SUBMODULE}/googlemock/include
 )
 
 add_library(gmock_main STATIC EXCLUDE_FROM_ALL
@@ -23,15 +23,19 @@ add_library(gmock_main STATIC EXCLUDE_FROM_ALL
 )
 
 target_include_directories(gmock_main PRIVATE
-                           ${GOOGLETEST_SUBMODULE}/googletest
-                           ${GOOGLETEST_SUBMODULE}/googlemock
+            SYSTEM ${GOOGLETEST_SUBMODULE}/googletest
+            SYSTEM ${GOOGLETEST_SUBMODULE}/googlemock
 )
 
-target_compile_options(gmock_main PUBLIC
+target_compile_options(gmock_main PRIVATE
+                       "-Wno-error"  # Third-party code is not our responsibility.
                        "-Wno-switch-enum"
                        "-Wno-zero-as-null-pointer-constant"
                        "-Wno-missing-declarations"
                        "-Wno-sign-conversion"
+                       "-Wno-double-promotion"
+                       "-Wno-float-equal"
+                       "-Wno-conversion"
                        "-DGTEST_HAS_PTHREAD=0"
                        "${NUNAVUT_VERIFICATION_EXTRA_COMPILE_CFLAGS}"
                        )

--- a/verification/cpp/suite/test_helpers.hpp
+++ b/verification/cpp/suite/test_helpers.hpp
@@ -9,7 +9,7 @@
 #include "gmock/gmock.h"
 #include "nunavut/support/serialization.hpp"
 
-testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
+inline testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
     using namespace nunavut::support;
     switch(e){
     case Error::SERIALIZATION_INVALID_ARGUMENT: s << "SERIALIZATION_INVALID_ARGUMENT"; break;
@@ -107,7 +107,7 @@ inline double randF64(void)
     return static_cast<double>(randI64());
 }
 
-::testing::AssertionResult CompareFloatsNear(float f1, float f2, float delta) {
+inline ::testing::AssertionResult CompareFloatsNear(float f1, float f2, float delta) {
   if (std::abs(f1-f2) < delta)
     return testing::AssertionSuccess();
   else

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -484,6 +484,7 @@ TEST(Serialization, Primitive)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include "regulated/zubax/actuator/esc/Status_0_1.h"
 #pragma GCC diagnostic pop
 

--- a/verification/cpp/suite/test_serialization.cpp
+++ b/verification/cpp/suite/test_serialization.cpp
@@ -495,12 +495,12 @@ TEST(Serialization, CCppBackAndForth)
         // We first create a real-world structure with random data:
         regulated::zubax::actuator::esc::Status_0_1 cpp_part;
         cpp_part.index = randI8() & 0x3F;
-        cpp_part.demand_factor = randI8();
+        cpp_part.demand_factor = randU8();
         cpp_part.dc_voltage_warning = randI8() & 0x1;
         cpp_part.overload_warning = randI8() & 0x1;
         cpp_part.motor_temperature_warning = randI8() & 0x1;
         cpp_part.inverter_temperature_warning = randI8() & 0x1;
-        cpp_part.error_count = randI32();
+        cpp_part.error_count = randU32();
         cpp_part.motor_mechanical_angular_velocity.radian_per_second = randF32();
         cpp_part.motor_torque.newton_meter = randF32();
         cpp_part.motor_electrical_frequency.hertz = randF32();

--- a/verification/cpp/suite/test_var_len_arr.cpp
+++ b/verification/cpp/suite/test_var_len_arr.cpp
@@ -511,6 +511,13 @@ TEST(VLATestsNonTrivialSpecific, TestBoolIterator)
     b[5] = false;
     ASSERT_EQ(true, *a);
     ASSERT_EQ(false, b[5]);
+    // Flip bit.
+    ASSERT_EQ(false, a[7]);
+    ASSERT_EQ(true, foo[7]);
+    a[7].flip();
+    foo[7].flip();
+    ASSERT_EQ(true, a[7]);
+    ASSERT_EQ(false, foo[7]);
     // Check the final state.
     ASSERT_EQ(10, foo.size());
     ASSERT_EQ(10, foo.capacity());
@@ -521,12 +528,12 @@ TEST(VLATestsNonTrivialSpecific, TestBoolIterator)
     ASSERT_EQ(true, foo.at(4));
     ASSERT_EQ(false, foo.at(5));
     ASSERT_EQ(false, foo.at(6));
-    ASSERT_EQ(true, foo.at(7));
+    ASSERT_EQ(false, foo.at(7));
     ASSERT_EQ(true, foo.at(8));
-    ASSERT_EQ(false, foo.at(9));
+    ASSERT_EQ(true, foo.at(9));
     // Constant iterators.
     ASSERT_EQ(false, *foo.cbegin());
-    ASSERT_EQ(false, *(foo.cend() - 1));
+    ASSERT_EQ(true, *(foo.cend() - 1));
     ASSERT_EQ(true, foo.cbegin()[2]);
 }
 

--- a/verification/cpp/suite/test_var_len_arr_compiles.cpp
+++ b/verification/cpp/suite/test_var_len_arr_compiles.cpp
@@ -118,8 +118,12 @@ struct NotThrowyThing
 
 template <class T>
 class TestDefaultAllocator : public testing::Test { };
-TYPED_TEST_SUITE_P(TestDefaultAllocator);
-TYPED_TEST_P(TestDefaultAllocator, X)
+using DefaultAllocatorTypes = ::testing::Types<
+    nunavut::support::VariableLengthArray<int, 10>,
+    nunavut::support::VariableLengthArray<bool, 10>
+>;
+TYPED_TEST_SUITE(TestDefaultAllocator, DefaultAllocatorTypes);
+TYPED_TEST(TestDefaultAllocator, X)
 {
     TypeParam subject;
 
@@ -141,19 +145,17 @@ TYPED_TEST_P(TestDefaultAllocator, X)
     // Use the subject to ensure it isn't elided.
     ASSERT_EQ(0U, subject.size());
 }
-REGISTER_TYPED_TEST_SUITE_P(TestDefaultAllocator, X);
-using DefaultAllocatorTypes = ::testing::Types<
-    nunavut::support::VariableLengthArray<int, 10>,
-    nunavut::support::VariableLengthArray<bool, 10>
->;
-INSTANTIATE_TYPED_TEST_SUITE_P(X, TestDefaultAllocator, DefaultAllocatorTypes);
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 template <class T>
 class TestNoThrowAllocator : public testing::Test { };
-TYPED_TEST_SUITE_P(TestNoThrowAllocator);
-TYPED_TEST_P(TestNoThrowAllocator, X)
+using NoThrowAllocatorTypes = ::testing::Types<
+    nunavut::support::VariableLengthArray<int, 10, JunkyNoThrowAllocator<int, 10>>,
+    nunavut::support::VariableLengthArray<bool, 10, JunkyNoThrowAllocator<bool, 10>>
+>;
+TYPED_TEST_SUITE(TestNoThrowAllocator, NoThrowAllocatorTypes);
+TYPED_TEST(TestNoThrowAllocator, X)
 {
     TypeParam subject;
 
@@ -176,19 +178,17 @@ TYPED_TEST_P(TestNoThrowAllocator, X)
     // Use the subject to ensure it isn't elided.
     ASSERT_EQ(0U, subject.size());
 }
-REGISTER_TYPED_TEST_SUITE_P(TestNoThrowAllocator, X);
-using NoThrowAllocatorTypes = ::testing::Types<
-    nunavut::support::VariableLengthArray<int, 10, JunkyNoThrowAllocator<int, 10>>,
-    nunavut::support::VariableLengthArray<bool, 10, JunkyNoThrowAllocator<bool, 10>>
->;
-INSTANTIATE_TYPED_TEST_SUITE_P(X, TestNoThrowAllocator, NoThrowAllocatorTypes);
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 template <class T>
 class TestThrowingAllocator : public testing::Test { };
-TYPED_TEST_SUITE_P(TestThrowingAllocator);
-TYPED_TEST_P(TestThrowingAllocator, X)
+using ThrowingAllocatorTypes = ::testing::Types<
+    nunavut::support::VariableLengthArray<int, 10, JunkyThrowingAllocator<int, 10>>,
+    nunavut::support::VariableLengthArray<bool, 10, JunkyThrowingAllocator<int, 10>>
+>;
+TYPED_TEST_SUITE(TestThrowingAllocator, ThrowingAllocatorTypes);
+TYPED_TEST(TestThrowingAllocator, X)
 {
     TypeParam subject;
 
@@ -213,12 +213,6 @@ TYPED_TEST_P(TestThrowingAllocator, X)
     // Use the subject to ensure it isn't elided.
     ASSERT_EQ(0U, subject.size());
 }
-REGISTER_TYPED_TEST_SUITE_P(TestThrowingAllocator, X);
-using ThrowingAllocatorTypes = ::testing::Types<
-    nunavut::support::VariableLengthArray<int, 10, JunkyThrowingAllocator<int, 10>>,
-    nunavut::support::VariableLengthArray<bool, 10, JunkyThrowingAllocator<int, 10>>
->;
-INSTANTIATE_TYPED_TEST_SUITE_P(X, TestThrowingAllocator, ThrowingAllocatorTypes);
 
 // ---------------------------------------------------------------------------------------------------------------------
 

--- a/verification/cpp/suite/test_var_len_arr_compiles.cpp
+++ b/verification/cpp/suite/test_var_len_arr_compiles.cpp
@@ -122,7 +122,7 @@ using DefaultAllocatorTypes = ::testing::Types<
     nunavut::support::VariableLengthArray<int, 10>,
     nunavut::support::VariableLengthArray<bool, 10>
 >;
-TYPED_TEST_SUITE(TestDefaultAllocator, DefaultAllocatorTypes);
+TYPED_TEST_SUITE(TestDefaultAllocator, DefaultAllocatorTypes, );
 TYPED_TEST(TestDefaultAllocator, X)
 {
     TypeParam subject;
@@ -154,7 +154,7 @@ using NoThrowAllocatorTypes = ::testing::Types<
     nunavut::support::VariableLengthArray<int, 10, JunkyNoThrowAllocator<int, 10>>,
     nunavut::support::VariableLengthArray<bool, 10, JunkyNoThrowAllocator<bool, 10>>
 >;
-TYPED_TEST_SUITE(TestNoThrowAllocator, NoThrowAllocatorTypes);
+TYPED_TEST_SUITE(TestNoThrowAllocator, NoThrowAllocatorTypes, );
 TYPED_TEST(TestNoThrowAllocator, X)
 {
     TypeParam subject;
@@ -187,7 +187,7 @@ using ThrowingAllocatorTypes = ::testing::Types<
     nunavut::support::VariableLengthArray<int, 10, JunkyThrowingAllocator<int, 10>>,
     nunavut::support::VariableLengthArray<bool, 10, JunkyThrowingAllocator<int, 10>>
 >;
-TYPED_TEST_SUITE(TestThrowingAllocator, ThrowingAllocatorTypes);
+TYPED_TEST_SUITE(TestThrowingAllocator, ThrowingAllocatorTypes, );
 TYPED_TEST(TestThrowingAllocator, X)
 {
     TypeParam subject;


### PR DESCRIPTION
- Add bool specialization for VariableLengthArray; fix #260 
- Fix #281 
- Update Google Test to the latest version v1.13
- Fix incorrect handling of compilation flags in `Findgtest.cmake`
- Fix warnings revealed by the above fix

There is a fair amount of code duplication between the generic and specialized versions of `VariableLengthArray`. It is possible to eliminate some of it by extracting commonalities into a base class.