### PR TITLE
C++: Avoid name collisions and add missing const begin()/end() methods to VLA

### DIFF
--- a/src/nunavut/_version.py
+++ b/src/nunavut/_version.py
@@ -8,7 +8,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 __license__ = "MIT"
 __author__ = "OpenCyphal"
 __copyright__ = "Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved. Copyright (c) 2022 OpenCyphal."

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -116,12 +116,11 @@ using const_bytespan = span<const {{ typename_byte }}> ;
 /// (128 is not used). Error code 1 is currently also not used to avoid conflicts with 3rd-party software.
 enum class Error{
     // API usage errors:
-    SERIALIZATION_INVALID_ARGUMENT = 2,
-    SERIALIZATION_BUFFER_TOO_SMALL = 3,
+    SerializationBufferTooSmall = 3,
     // Invalid representation (caused by bad input data, not API misuse):
-    REPRESENTATION_BAD_ARRAY_LENGTH=10,
-    REPRESENTATION_BAD_UNION_TAG=11,
-    REPRESENTATION_BAD_DELIMITER_HEADER=12
+    SerializationBadArrayLength=10,
+    RepresentationBadUnionTag=11,
+    RepresentationBadDelimiterHeader=12
 };
 
 
@@ -576,7 +575,7 @@ public:
 
 inline VoidResult bitspan::setZeros({{ typename_unsigned_bit_length }} length){
     if(length > size()){
-        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+        return -Error::SerializationBufferTooSmall;
     }
     if(length == 0){
         return {};
@@ -614,12 +613,12 @@ inline Result<bitspan> bitspan::subspan({# -#}
     const {{ typename_unsigned_length }} new_offset_bits = offset_bits % 8U;
     {{ assert('offset_bytes * 8U <= offset_bits') }}
     if(offset_bytes > data_.size()){
-        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+        return -Error::SerializationBufferTooSmall;
     }
     const {{ typename_unsigned_length }} new_size_bits = new_offset_bits + size_bits;
     const {{ typename_unsigned_length }} size_available_bits = (data_.size() - offset_bytes) * 8U;
     if(new_size_bits > size_available_bits){
-        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+        return -Error::SerializationBufferTooSmall;
     }
     const {{ typename_unsigned_length }} new_size_bytes = new_size_bits / 8U;
     return bitspan( data_.data() + offset_bytes, new_size_bytes, new_offset_bits);
@@ -739,7 +738,7 @@ inline VoidResult bitspan::setBit(const bool value)
 {
     if ((data_.size() * 8U) <= offset_bits_)
     {
-        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+        return -Error::SerializationBufferTooSmall;
     }
     const uint8_t val = value ? 1U : 0U;
     const_bitspan{ &val, 1U }.copyTo(*this, 1U);
@@ -751,7 +750,7 @@ inline VoidResult bitspan::setUxx(const uint64_t value, const uint8_t len_bits)
     static_assert(64U == (sizeof(uint64_t) * 8U), "Unexpected size of uint64_t");
     if ((data_.size() * 8) < (offset_bits_ + len_bits))
     {
-        return -Error::SERIALIZATION_BUFFER_TOO_SMALL;
+        return -Error::SerializationBufferTooSmall;
     }
     const {{ typename_unsigned_bit_length }} saturated_len_bits = std::min<{{ typename_unsigned_bit_length }}>({# -#}
         len_bits, 64U);

--- a/src/nunavut/lang/cpp/support/variable_length_array.hpp
+++ b/src/nunavut/lang/cpp/support/variable_length_array.hpp
@@ -300,6 +300,10 @@ public:
     {
         return data_;
     }
+    constexpr const_iterator begin() const noexcept
+    {
+        return cbegin();
+    }
 
     ///
     /// Pointer to memory location after the last, valid element. This pointer
@@ -315,6 +319,10 @@ public:
         {
             return &data_[size_];
         }
+    }
+    constexpr const_iterator end() const noexcept
+    {
+        return cend();
     }
 
     ///
@@ -1280,6 +1288,14 @@ public:
     constexpr iterator end() noexcept
     {
         return iterator(*this, size_);
+    }
+    constexpr const_iterator begin() const noexcept
+    {
+        return cbegin();
+    }
+    constexpr const_iterator end() const noexcept
+    {
+        return cend();
     }
 
     ///

--- a/src/nunavut/lang/cpp/templates/ServiceType.j2
+++ b/src/nunavut/lang/cpp/templates/ServiceType.j2
@@ -13,13 +13,18 @@
 {% set composite_type = T.response_type %}{% include '_composite_type.j2' %}
 
 struct {{ 'Service_%s_%s' | format(T.version.major, T.version.minor) }} {
-    static constexpr bool IsServiceType = true;
-    static constexpr bool IsService = true;
-    static constexpr bool IsRequest = false;
-    static constexpr bool IsResponse = false;
+    struct _traits_
+    {
+        _traits_() = delete;
 
-    using Request = {{ T.request_type | short_reference_name }};
-    using Response = {{ T.response_type | short_reference_name }};
+        static constexpr bool IsServiceType = true;
+        static constexpr bool IsService = true;
+        static constexpr bool IsRequest = false;
+        static constexpr bool IsResponse = false;
+
+        using Request = {{ T.request_type | short_reference_name }};
+        using Response = {{ T.response_type | short_reference_name }};
+    };
 };
 
 }{{ T | definition_end }}

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -33,42 +33,53 @@
 {% endif -%}
 {{ composite_type | definition_begin }} final
 {
-    // +---------------------------------------------------------------------------------------------------------------+
-    // | PORT IDENTIFIERS
-    // +---------------------------------------------------------------------------------------------------------------+
+    struct _traits_  // The name is surrounded with underscores to avoid collisions with DSDL attributes.
+    {
+        _traits_() = delete;
 {%- if T.has_fixed_port_id %}
-    static constexpr bool HasFixedPortID = true;
-    static constexpr {{ typename_unsigned_port }} FixedPortId = {{ T.fixed_port_id }}U;
+        static constexpr bool HasFixedPortID = true;
+        static constexpr {{ typename_unsigned_port }} FixedPortId = {{ T.fixed_port_id }}U;
 {%- else %}
-    /// This type does not have a fixed port-ID. See https://forum.opencyphal.org/t/choosing-message-and-service-ids/889
-    static constexpr bool HasFixedPortID = false;
+        /// This type does not have a fixed port-ID. See https://forum.opencyphal.org/t/choosing-message-and-service-ids/889
+        static constexpr bool HasFixedPortID = false;
 {% endif -%}
 {%- if T is ServiceType %}
-    static constexpr bool IsServiceType = true;
-    static constexpr bool IsService = false;
-    static constexpr bool IsRequest = {{ (composite_type == T.request_type) | string | lower }};
-    static constexpr bool IsResponse = {{ (composite_type == T.response_type) | string | lower }};
+        static constexpr bool IsServiceType  = true;
+        static constexpr bool IsService      = false;
+        static constexpr bool IsRequest      = {{ (composite_type == T.request_type) | string | lower }};
+        static constexpr bool IsResponse     = {{ (composite_type == T.response_type) | string | lower }};
 {%- else %}
-    static constexpr bool IsServiceType = false;
+        static constexpr bool IsServiceType = false;
 {% endif -%}
     {%- assert composite_type.extent % 8 == 0 %}
     {%- assert composite_type.inner_type.extent % 8 == 0 %}
-    /// Extent is the minimum amount of memory required to hold any serialized representation of any compatible
-    /// version of the data type; or, on other words, it is the the maximum possible size of received objects of this type.
-    /// The size is specified in bytes (rather than bits) because by definition, extent is an integer number of bytes long.
-    /// When allocating a deserialization (RX) buffer for this data type, it should be at least extent bytes large.
-    /// When allocating a serialization (TX) buffer, it is safe to use the size of the largest serialized representation
-    /// instead of the extent because it provides a tighter bound of the object size; it is safe because the concrete type
-    /// is always known during serialization (unlike deserialization). If not sure, use extent everywhere.
-
-    static constexpr {{ typename_unsigned_length }} EXTENT_BYTES                    = {#- -#}
-        {{ composite_type.extent // 8 }}UL;
-    static constexpr {{ typename_unsigned_length }} SERIALIZATION_BUFFER_SIZE_BYTES = {#- -#}
-        {{ composite_type.inner_type.extent // 8 }}UL;
-    static_assert(EXTENT_BYTES >= SERIALIZATION_BUFFER_SIZE_BYTES, "Internal constraint violation");
-    static_assert({# -#}
-        EXTENT_BYTES < (std::numeric_limits<{{ typename_unsigned_bit_length }}>::max() /8U), {# -#}
-        "This message is too large to be handled by current types!");
+        /// Extent is the minimum amount of memory required to hold any serialized representation of any compatible
+        /// version of the data type; or, on other words, it is the the maximum possible size of received objects of this type.
+        /// The size is specified in bytes (rather than bits) because by definition, extent is an integer number of bytes long.
+        /// When allocating a deserialization (RX) buffer for this data type, it should be at least extent bytes large.
+        /// When allocating a serialization (TX) buffer, it is safe to use the size of the largest serialized representation
+        /// instead of the extent because it provides a tighter bound of the object size; it is safe because the concrete type
+        /// is always known during serialization (unlike deserialization). If not sure, use extent everywhere.
+        static constexpr {{ typename_unsigned_length }} ExtentBytes                  = {# -#}
+            {{ composite_type.extent // 8 }}UL;
+        static constexpr {{ typename_unsigned_length }} SerializationBufferSizeBytes = {# -#}
+            {{ composite_type.inner_type.extent // 8 }}UL;
+        static_assert(ExtentBytes >= SerializationBufferSizeBytes, "Internal constraint violation");
+        static_assert({# -#}
+            ExtentBytes < (std::numeric_limits<{{ typename_unsigned_bit_length }}>::max() / 8U), {# -#}
+            "This message is too large to be handled by the selected types");
+{%- for field in composite_type.fields_except_padding %}
+    {%- if loop.first %}
+        struct TypeOf
+        {
+            TypeOf() = delete;
+    {%- endif %}
+            using {{field.name|id}} = {{ field.data_type | declaration }};
+    {%- if loop.last %}
+        };
+    {%- endif %}
+{%- endfor %}
+    };
 
 {%- for constant in composite_type.constants %}
     {% if loop.first %}
@@ -86,51 +97,52 @@
 {% include '_fields_as_union.j2' %}
 {%- endifuses -%}
 {%- for field in composite_type.fields_except_padding %}
-    bool is_{{ field.name | id }}() const {
-        return VariantType::IndexOf::{{ field.name | id }} == union_value.index();
+    bool is_{{field.name|id}}() const {
+        return VariantType::IndexOf::{{field.name|id}} == union_value.index();
     }
 
-    typename std::add_pointer<{{ field.data_type | declaration }}>::type get_{{ field.name | id }}_if(){
-        return VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+    typename std::add_pointer<_traits_::TypeOf::{{field.name|id}}>::type get_{{field.name|id}}_if(){
+        return VariantType::get_if<VariantType::IndexOf::{{field.name|id}}>(&union_value);
     }
 
-    typename std::add_pointer<const {{ field.data_type | declaration }}>::type get_{{ field.name | id }}_if() const{
-        return VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+    typename std::add_pointer<const _traits_::TypeOf::{{field.name|id}}>::type get_{{field.name|id}}_if() const{
+        return VariantType::get_if<VariantType::IndexOf::{{field.name|id}}>(&union_value);
     }
 
-    typename std::add_lvalue_reference<{{ field.data_type | declaration }}>::type get_{{ field.name | id }}(){
+    typename std::add_lvalue_reference<_traits_::TypeOf::{{field.name|id}}>::type get_{{field.name|id}}(){
         {{ assert('is_%s()' | format(field.name | id)) }}
-        return *VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+        return *VariantType::get_if<VariantType::IndexOf::{{field.name|id}}>(&union_value);
     }
 
-    typename std::add_lvalue_reference<const {{ field.data_type | declaration }}>::type get_{{ field.name | id }}() const{
+    typename std::add_lvalue_reference<const _traits_::TypeOf::{{field.name|id}}>::type get_{{field.name|id}}() const{
         {{ assert('is_%s()' | format(field.name | id)) }}
-        return *VariantType::get_if<VariantType::IndexOf::{{ field.name | id }}>(&union_value);
+        return *VariantType::get_if<VariantType::IndexOf::{{field.name|id}}>(&union_value);
     }
 
-    template<class... Args> typename std::add_lvalue_reference<{{ field.data_type | declaration }}>::type
-    set_{{ field.name | id }}(Args&&...v){
-        return union_value.emplace<VariantType::IndexOf::{{ field.name | id }}>(v...);
+    template<class... Args> typename std::add_lvalue_reference<_traits_::TypeOf::{{field.name|id}}>::type
+    set_{{field.name|id}}(Args&&...v){
+        return union_value.emplace<VariantType::IndexOf::{{field.name|id}}>(v...);
     }
 {%- endfor %}
 {%- else -%}
 {% include '_fields.j2' %}
-{%- endif -%}
-{%- if not nunavut.support.omit %}
-
-    nunavut::support::SerializeResult
-    serialize(nunavut::support::bitspan out_buffer) const
-    {
-        {% from 'serialization.j2' import serialize -%}
-        {{ serialize(composite_type) | trim | remove_blank_lines | indent }}
-    }
-
-    nunavut::support::SerializeResult
-    deserialize(nunavut::support::const_bitspan in_buffer)
-    {
-        {% from 'deserialization.j2' import deserialize -%}
-        {{ deserialize(composite_type) | trim | remove_blank_lines | indent }}
-    }
 {%- endif %}
 }{{ composite_type | definition_end }}
+
+{% if not nunavut.support.omit %}
+inline nunavut::support::SerializeResult serialize(const {{composite_type|short_reference_name}}& obj,
+                                                   nunavut::support::bitspan out_buffer)
+{
+    {% from 'serialization.j2' import serialize -%}
+    {{ serialize(composite_type) | trim | remove_blank_lines }}
+}
+
+inline nunavut::support::SerializeResult deserialize({{composite_type|short_reference_name}}& obj,
+                                                     nunavut::support::const_bitspan in_buffer)
+{
+    {% from 'deserialization.j2' import deserialize -%}
+    {{ deserialize(composite_type) | trim | remove_blank_lines }}
+}
+{%- endif %}
+
 {#- -#}

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -28,6 +28,9 @@
 // +-------------------------------------------------------------------------------------------------------------------+
 {% endifuses -%}
 {{ composite_type.doc | block_comment('cpp-doxygen', 0, 120) }}
+{% if composite_type.deprecated -%}
+[[deprecated("{{ composite_type }} is reaching the end of its life; there may be a newer version available"))]]
+{% endif -%}
 {{ composite_type | definition_begin }} final
 {
     // +---------------------------------------------------------------------------------------------------------------+

--- a/src/nunavut/lang/cpp/templates/_fields.j2
+++ b/src/nunavut/lang/cpp/templates/_fields.j2
@@ -10,5 +10,5 @@
     // +----------------------------------------------------------------------+
     {% endif -%}
     {{ field.doc | block_comment('cpp-doxygen', 4, 120) }}
-    {{ field.data_type | declaration }} {{ field | id }}{{ field.data_type | default_value_initializer }};
+    _traits_::TypeOf::{{field.name|id}} {{ field | id }}{{ field.data_type | default_value_initializer }};
 {%- endfor -%}

--- a/src/nunavut/lang/cpp/templates/_fields_as_variant.j2
+++ b/src/nunavut/lang/cpp/templates/_fields_as_variant.j2
@@ -6,7 +6,7 @@
     class VariantType final : public std::variant<
 {%- for field in composite_type.fields_except_padding %}
         {{ field.doc | block_comment('cpp-doxygen', 8, 120) }}
-        {{ field.data_type | declaration }}{% if not loop.last %},{% endif %}
+        _traits_::TypeOf::{{field.name|id}}{% if not loop.last %},{% endif %}
 {%- endfor %}
     >
     {

--- a/src/nunavut/lang/cpp/templates/deserialization.j2
+++ b/src/nunavut/lang/cpp/templates/deserialization.j2
@@ -14,6 +14,7 @@
     {{ _deserialize_impl(t) }}
 {% else %}
     (void)(in_buffer);
+    (void)(obj);
     return 0;
 {% endif %}
 {% endmacro %}
@@ -30,26 +31,27 @@
     {{ _pad_to_alignment(f.data_type.alignment_requirement) }}
         {%- endif %}
     // {{ f }}
-    {{ _deserialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines }}
+    {{ _deserialize_any(f.data_type, "obj.%s"|format(f|id), offset)|trim|remove_blank_lines }}
     {% endfor %}
 {% elif t.inner_type is UnionType %}
+    using VariantType = {{t|short_reference_name}}::VariantType;
     // Union tag field: {{ t.inner_type.tag_field_type }}
     {% set ref_index = 'index'|to_template_unique_name %}
-    auto {{ ref_index }} = union_value.index();
+    auto {{ ref_index }} = obj.union_value.index();
     {{ _deserialize_integer(t.inner_type.tag_field_type, ref_index, 0|bit_length_set)|trim|remove_blank_lines }}
     {% for f, offset in t.inner_type.iterate_fields_with_offsets() %}
     {{ 'if' if loop.first else 'else if' }} (VariantType::IndexOf::{{ f| id }} == {{ ref_index }})
     {
-        set_{{ f| id }}();
+        obj.set_{{f|id}}();
         {% set ref_ptr = 'ptr'|to_template_unique_name %}
-        auto {{ ref_ptr }} = get_{{ f| id }}_if();
+        auto {{ref_ptr}} = obj.get_{{f|id}}_if();
         {%- assert f.data_type.alignment_requirement <= (offset.min) %}
         {{ _deserialize_any(f.data_type, '(*%s)' | format(ref_ptr), offset)|trim|remove_blank_lines|indent }}
     }
     {%- endfor %}
     else
     {
-        return -nunavut::support::Error::REPRESENTATION_BAD_UNION_TAG;
+        return -nunavut::support::Error::RepresentationBadUnionTag;
     }
 {% else %}{% assert False %}
 {% endif %}
@@ -185,7 +187,7 @@
         {{ _deserialize_integer(t.length_field_type, ('const %s %s'|format((t.length_field_type | declaration), ref_size)) , offset) }}
         if ( {{ ref_size }} > {{ t.capacity }}U)
         {
-            return -nunavut::support::Error::REPRESENTATION_BAD_ARRAY_LENGTH;
+            return -nunavut::support::Error::SerializationBadArrayLength;
         }
         {{ reference }}.reserve({{ ref_size }});
 
@@ -226,14 +228,14 @@
         {{ _deserialize_integer(t.delimiter_header_type, ref_size_bytes, offset)|trim|indent }}
         if (({{ ref_size_bytes }} * 8U) > in_buffer.size())
         {
-            return -nunavut::support::Error::REPRESENTATION_BAD_DELIMITER_HEADER;
+            return -nunavut::support::Error::RepresentationBadDelimiterHeader;
         }
         const {{ typename_unsigned_length }} {{ref_delimiter}} = {{ ref_size_bytes }};
 {% endif %}
 
         {{ assert('in_buffer.offset_alings_to_byte()') }}
         {
-            const auto {{ ref_err }} = {{ reference }}.deserialize(in_buffer.subspan());
+            const auto {{ ref_err }} = deserialize({{ reference }}, in_buffer.subspan());
             if({{ ref_err }}){
                 {{ ref_size_bytes }} = {{ ref_err }}.value();
             }else{

--- a/src/nunavut/lang/cpp/templates/serialization.j2
+++ b/src/nunavut/lang/cpp/templates/serialization.j2
@@ -14,6 +14,7 @@
     {{ _serialize_impl(t) }}
 {% else %}
     (void)(out_buffer);
+    (void)(obj);
     return 0U;
 {% endif %}
 {% endmacro %}
@@ -29,7 +30,7 @@
 {% endif %}
     if ((static_cast<{{ typename_unsigned_bit_length }}>(capacity_bits)) < {{ t.inner_type.bit_length_set.max }}UL)
     {
-        return -nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL;
+        return -nunavut::support::Error::SerializationBufferTooSmall;
     }
 {%- if options.enable_override_variable_array_capacity %}
 #endif // ndef {{ t | full_macro_name }}_DISABLE_SERIALIZATION_BUFFER_CHECK_
@@ -46,12 +47,13 @@
     {{ _pad_to_alignment(f.data_type.alignment_requirement)|trim|remove_blank_lines }}
         {%- endif %}
     {   // {{ f }}
-        {{ _serialize_any(f.data_type, (f|id), offset)|trim|remove_blank_lines|indent }}
+        {{ _serialize_any(f.data_type, "obj.%s"|format(f|id), offset)|trim|remove_blank_lines|indent }}
     }
     {%- endfor %}
 {% elif t.inner_type is UnionType %}
+    using VariantType = {{t|short_reference_name}}::VariantType;
     {% set ref_index = 'index'|to_template_unique_name %}
-    const auto {{ ref_index }} = union_value.index();
+    const auto {{ ref_index }} = obj.union_value.index();
     {   // Union tag field: {{ t.inner_type.tag_field_type }}
         {{
             _serialize_integer(t.inner_type.tag_field_type, ref_index, 0|bit_length_set)
@@ -62,14 +64,14 @@
     {{ 'if' if loop.first else 'else if' }} (VariantType::IndexOf::{{ f| id }} == {{ ref_index }})
     {
         {% set ref_ptr = 'ptr'|to_template_unique_name %}
-        auto {{ ref_ptr }} = get_{{ f| id }}_if();
+        auto {{ ref_ptr }} = obj.get_{{f|id}}_if();
         {%- assert f.data_type.alignment_requirement <= (offset.min) %}
         {{ _serialize_any(f.data_type, '(*%s)' | format(ref_ptr), offset)|trim|remove_blank_lines|indent }}
     }
     {%- endfor %}
     else
     {
-        return -nunavut::support::Error::REPRESENTATION_BAD_UNION_TAG;
+        return -nunavut::support::Error::RepresentationBadUnionTag;
     }
 {% else %}{% assert False %}
 {% endif %}
@@ -290,7 +292,7 @@
 {% macro _serialize_variable_length_array(t, reference, offset) %}
     if ({{ reference }}.size() > {{ t.capacity }})
     {
-        return -nunavut::support::Error::REPRESENTATION_BAD_ARRAY_LENGTH;
+        return -nunavut::support::Error::SerializationBadArrayLength;
     }
     // Array length prefix: {{ t.length_field_type }}
     {{ _serialize_integer(t.length_field_type, reference + '.size()', offset) }}
@@ -340,7 +342,7 @@
 
 {# NESTED OBJECT SERIALIZATION #}
     {{ assert('%s->offset_alings_to_byte()' | format(ref_subspan)) }}
-    auto {{ ref_err }} = {{ reference }}.serialize({{ ref_subspan }}.value());
+    auto {{ ref_err }} = serialize({{ reference }}, {{ ref_subspan }}.value());
     if (not {{ ref_err }})
     {
         return {{ ref_err }};

--- a/test/gentest_arrays/test_arrays.py
+++ b/test/gentest_arrays/test_arrays.py
@@ -47,7 +47,7 @@ def test_default_array_type_cpp(gen_paths):  # type: ignore
 
     assert_pattern_match_in_file(
         gen_paths.find_outfile_in_namespace("radar.Phased", namespace),
-        re.compile(r"\s*std::array<float,3>\s+bank_normal_rads{};\s*"),
+        re.compile(r"\s*using *bank_normal_rads *= *std::array<float,3>;\s*"),
     )
 
 
@@ -72,6 +72,6 @@ def test_var_array_override_cpp(gen_paths):  # type: ignore
 
     assert_pattern_match_in_file(
         gen_paths.find_outfile_in_namespace("radar.Phased", namespace),
-        re.compile(r"\s*scotec::TerribleArray<float,2677>\s+antennae_per_bank{};\s*"),
-        re.compile(r"\s*std::array<float,3>\s+bank_normal_rads{};\s*"),
+        re.compile(r"\s*using *antennae_per_bank *= *scotec::TerribleArray<float,2677>;\s*"),
+        re.compile(r"\s*using *bank_normal_rads *= *std::array<float,3>;\s*"),
     )

--- a/verification/cpp/suite/test_bitarray.cpp
+++ b/verification/cpp/suite/test_bitarray.cpp
@@ -89,7 +89,7 @@ TEST(BitSpan, Subspan)
 
     res = sp.subspan(0U, 32U);
     ASSERT_FALSE(res);
-    ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, res.error());
+    ASSERT_EQ(nunavut::support::Error::SerializationBufferTooSmall, res.error());
 }
 
 TEST(BitSpan, AlignedPtr) {
@@ -337,7 +337,7 @@ TEST(BitSpan, SetIxx_bufferOverflow)
     ASSERT_EQ(0xAA, buffer[2]);
     rc = nunavut::support::bitspan{buffer, 2U, 2U*8U}.setIxx(0xAA, 8);
     ASSERT_FALSE(rc);
-    ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, rc.error());
+    ASSERT_EQ(nunavut::support::Error::SerializationBufferTooSmall, rc.error());
     ASSERT_EQ(0xAA, buffer[2]);
 }
 
@@ -370,7 +370,7 @@ TEST(BitSpan, SetBit_bufferOverflow)
     auto res = nunavut::support::bitspan{buffer, 1U, 8}.setBit(true);
 
     ASSERT_FALSE(res.has_value());
-    ASSERT_EQ(nunavut::support::Error::SERIALIZATION_BUFFER_TOO_SMALL, res.error());
+    ASSERT_EQ(nunavut::support::Error::SerializationBufferTooSmall, res.error());
     ASSERT_EQ(0x00, buffer[1]);
 }
 

--- a/verification/cpp/suite/test_helpers.hpp
+++ b/verification/cpp/suite/test_helpers.hpp
@@ -12,11 +12,10 @@
 inline testing::Message& operator<<(testing::Message& s, const nunavut::support::Error& e){
     using namespace nunavut::support;
     switch(e){
-    case Error::SERIALIZATION_INVALID_ARGUMENT: s << "SERIALIZATION_INVALID_ARGUMENT"; break;
-    case Error::SERIALIZATION_BUFFER_TOO_SMALL: s << "SERIALIZATION_BUFFER_TOO_SMALL"; break;
-    case Error::REPRESENTATION_BAD_ARRAY_LENGTH: s << "REPRESENTATION_BAD_ARRAY_LENGTH"; break;
-    case Error::REPRESENTATION_BAD_UNION_TAG: s << "REPRESENTATION_BAD_UNION_TAG"; break;
-    case Error::REPRESENTATION_BAD_DELIMITER_HEADER: s << "REPRESENTATION_BAD_DELIMITER_HEADER"; break;
+    case Error::SerializationBufferTooSmall: s << "SerializationBufferTooSmall"; break;
+    case Error::SerializationBadArrayLength: s << "SerializationBadArrayLength"; break;
+    case Error::RepresentationBadUnionTag: s << "RepresentationBadUnionTag"; break;
+    case Error::RepresentationBadDelimiterHeader: s << "RepresentationBadDelimiterHeader"; break;
     }
     return s;
 }

--- a/verification/cpp/suite/test_var_len_arr.cpp
+++ b/verification/cpp/suite/test_var_len_arr.cpp
@@ -403,6 +403,39 @@ TYPED_TEST(VLATestsNonTrivialCommon, TestPushBackGrowsCapacity)
     ASSERT_EQ(MaxSize, subject.capacity());
 }
 
+TYPED_TEST(VLATestsNonTrivialCommon, TestForEachConstIterators)
+{
+    static constexpr std::size_t                              MaxSize = 9;
+    nunavut::support::VariableLengthArray<TypeParam, MaxSize> subject;
+    auto& const_subject = subject;
+    ASSERT_EQ(0U, const_subject.size());
+    ASSERT_EQ(0U, const_subject.capacity());
+    for (const auto& item: const_subject)  // Requires begin() const, end() const.
+    {
+        (void) item;
+        FAIL();
+    }
+    ASSERT_EQ(0U, const_subject.size());
+    ASSERT_EQ(0U, const_subject.capacity());
+    for (std::size_t i = 0; i < MaxSize; ++i)
+    {
+        ASSERT_EQ(i, const_subject.size());
+        ASSERT_LE(i, const_subject.capacity());
+        subject.push_back(static_cast<TypeParam>(i));
+        ASSERT_EQ(i + 1, const_subject.size());
+        ASSERT_LE(i + 1, const_subject.capacity());
+    }
+    ASSERT_EQ(MaxSize, const_subject.size());
+    ASSERT_EQ(MaxSize, const_subject.capacity());
+    std::size_t i = 0;
+    for (const auto& item : const_subject)  // Requires begin() const, end() const.
+    {
+        ASSERT_EQ(static_cast<TypeParam>(i), item);
+        ++i;
+    }
+    ASSERT_EQ(MaxSize, i);
+}
+
 // +----------------------------------------------------------------------+
 /**
  * Test suite to ensure non-trivial objects are properly handled. This one contains non-generic cases.


### PR DESCRIPTION
Fixes #286 

In C++, `serialize` and `deserialize` are now free-standing functions. The alternative would be to name them `_serialize_` and `_deserialize_`, but I imagine this to be bad form.

One unused error tag `SERIALIZATION_INVALID_ARGUMENT` has been removed. The others have been renamed into CamelCase for consistency, as ALL_CAPS is reserved for macros.

I also added `_traits_::TypeOf` for introspection; it is often helpful in user code as the alternative requires the use of `decltype`:

<img width="712" alt="image" src="https://user-images.githubusercontent.com/3298404/222778681-69e1ac1e-ba45-418c-a26f-12b39ebc01ae.png">

We may also introduce a wrapper like `nunavut::traits<T>` if direct usage of `_traits_` is considered hard to read.