### PR TITLE
Add field initializing constructor, fix explicit, fix deserialization…

### DIFF
--- a/src/nunavut/lang/_config.py
+++ b/src/nunavut/lang/_config.py
@@ -33,7 +33,8 @@ class ConstructorConvention(Enum):
 
 
 class SpecialMethod(Enum):
-    DefaultConstructorWithOptionalAllocator = auto()
+    AllocatorConstructor = auto()
+    InitializingConstructorWithAllocator = auto()
     CopyConstructorWithAllocator = auto()
     MoveConstructorWithAllocator = auto()
 

--- a/src/nunavut/lang/_config.py
+++ b/src/nunavut/lang/_config.py
@@ -33,10 +33,21 @@ class ConstructorConvention(Enum):
 
 
 class SpecialMethod(Enum):
+    """
+    Enum used in the Jinja templates to differentiate different kinds of constructrors
+    """
+
     AllocatorConstructor = auto()
+    """ Constructor that takes an allocator as its single, required argument """
+
     InitializingConstructorWithAllocator = auto()
+    """ Constructor that takes an initializing value for each field followed by the allocator argument """
+
     CopyConstructorWithAllocator = auto()
+    """ Copy constructor that also takes an allocator argument """
+
     MoveConstructorWithAllocator = auto()
+    """ Move constructor that also takes an allocator argument """
 
 
 class LanguageConfig:

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -84,17 +84,43 @@ struct {{composite_type|short_reference_name}} final
 {%- endfor %}
     };
 {% if options.ctor_convention != ConstructorConvention.Default.value %}
+    {%- if options.allocator_is_default_constructible %}
     // Default constructor
-    {{composite_type|short_reference_name}}(const _traits_::allocator_type& allocator
+    {{composite_type|short_reference_name}}()
+    {%- if composite_type.fields_except_padding %} :{% endif %}
+    {%- for field in composite_type.fields_except_padding %}
+        {{ field | id }}{{ field.data_type | default_value_initializer }}{%if not loop.last %},{%endif %}
+    {%- endfor %}
+    {
+    }
+    {%- endif %}
+
+    // Allocator constructor
+    explicit {{composite_type|short_reference_name}}(const _traits_::allocator_type& allocator)
+    {%- if composite_type.fields_except_padding %} :{% endif %}
+    {%- for field in composite_type.fields_except_padding %}
+        {{ field | id }}{{ field | value_initializer(SpecialMethod.AllocatorConstructor) }}{%if not loop.last %},{%endif %}
+    {%- endfor %}
+    {
+        (void)allocator; // avoid unused param warning
+    }
+
+    {% if composite_type.fields_except_padding %}
+    // Initializing constructor
+    {{ composite_type | explicit_decorator(SpecialMethod.InitializingConstructorWithAllocator)}}(
+    {%- for field in composite_type.fields_except_padding %}
+        const _traits_::TypeOf::{{ field | id }}& {{ field | id }},
+    {%- endfor %}
+        const _traits_::allocator_type& allocator
     {%- if options.allocator_is_default_constructible %} = _traits_::allocator_type(){% endif %})
     {%- if composite_type.fields_except_padding %} :{% endif %}
     {%- for field in composite_type.fields_except_padding %}
-        {{ field | id }}{{ field | value_initializer(SpecialMethod.DefaultConstructorWithOptionalAllocator) }}{%if not loop.last %},{%endif %}
+        {{ field | id }}{{ field | value_initializer(SpecialMethod.InitializingConstructorWithAllocator) }}{%if not loop.last %},{%endif %}
     {%- endfor %}
-    { }
-
-    // Destructor
-    ~{{composite_type|short_reference_name}}() = default;
+    {
+        (void)allocator; // avoid unused param warning
+    }
+    {%- endif %}
 
     // Copy constructor
     {{composite_type|short_reference_name}}(const {{composite_type|short_reference_name}}&) = default;
@@ -106,6 +132,7 @@ struct {{composite_type|short_reference_name}} final
         {{ field | id }}{{ field | value_initializer(SpecialMethod.CopyConstructorWithAllocator) }}{%if not loop.last %},{%endif %}
     {%- endfor %}
     {
+        (void)allocator; // avoid unused param warning
     }
 
     // Move constructor
@@ -118,6 +145,7 @@ struct {{composite_type|short_reference_name}} final
         {{ field | id }}{{ field | value_initializer(SpecialMethod.MoveConstructorWithAllocator) }}{%if not loop.last %},{%endif %}
     {%- endfor %}
     {
+        (void)allocator; // avoid unused param warning
     }
 
     // Copy assignment
@@ -125,6 +153,9 @@ struct {{composite_type|short_reference_name}} final
 
     // Move assignment
     {{composite_type|short_reference_name}}& operator=({{composite_type|short_reference_name}}&&) = default;
+
+    // Destructor
+    ~{{composite_type|short_reference_name}}() = default;
 {%- endif %}
 
 {%- for constant in composite_type.constants %}

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -132,6 +132,7 @@ struct {{composite_type|short_reference_name}} final
         {{ field | id }}{{ field | value_initializer(SpecialMethod.CopyConstructorWithAllocator) }}{%if not loop.last %},{%endif %}
     {%- endfor %}
     {
+        (void)rhs;       // avoid unused param warning
         (void)allocator; // avoid unused param warning
     }
 
@@ -145,6 +146,7 @@ struct {{composite_type|short_reference_name}} final
         {{ field | id }}{{ field | value_initializer(SpecialMethod.MoveConstructorWithAllocator) }}{%if not loop.last %},{%endif %}
     {%- endfor %}
     {
+        (void)rhs;       // avoid unused param warning
         (void)allocator; // avoid unused param warning
     }
 

--- a/src/nunavut/lang/cpp/templates/deserialization.j2
+++ b/src/nunavut/lang/cpp/templates/deserialization.j2
@@ -204,7 +204,7 @@
     {% set tmp_element = 'tmp'|to_template_unique_name %}
         for ({{ typename_unsigned_length }} {{ ref_index }} = 0U; {{ ref_index }} < {{ ref_size }}; ++{{ ref_index }})
         {
-            {{ t.element_type | declaration }} {{ tmp_element }} = {{ t.element_type | declaration }}();
+            {{ t.element_type | declaration }} {{ tmp_element }} = {{ t.element_type | declaration }}({{ t.element_type | default_construction(reference) }});
             {{
                 _deserialize_any(t.element_type, tmp_element, element_offset)
             |trim|indent

--- a/verification/cpp/suite/test_array_c++17-pmr.cpp
+++ b/verification/cpp/suite/test_array_c++17-pmr.cpp
@@ -9,7 +9,9 @@
 
 #include "gmock/gmock.h"
 #include "mymsgs/Inner_1_0.hpp"
+#include "mymsgs/InnerMore_1_0.hpp"
 #include "mymsgs/Outer_1_0.hpp"
+#include "mymsgs/OuterMore_1_0.hpp"
 
 
 /**
@@ -69,38 +71,60 @@ TEST(StdVectorPmrTests, TestOuter) {
  * Serialization roundtrip using std::pmr::polymorphic_allocator
  */
 TEST(StdVectorTests, SerializationRoundtrip) {
-    std::array<std::byte, 200> buffer{};
+    std::array<std::byte, 500> buffer{};
     std::pmr::monotonic_buffer_resource mbr{buffer.data(), buffer.size(), std::pmr::null_memory_resource()};
-    std::pmr::polymorphic_allocator<mymsgs::Outer_1_0> pa{&mbr};
+    std::pmr::polymorphic_allocator<mymsgs::OuterMore_1_0> pa{&mbr};
 
     // Fill the data: inner first, then outer
-    mymsgs::Outer_1_0 outer1{pa};
-    outer1.inner.inner_items.reserve(5);
-    for (std::uint32_t i = 0; i < 5; i++) {
-        outer1.inner.inner_items.push_back(i);
-    }
-    outer1.outer_items.reserve(8);
-    for (float i = 0; i < 8; i++) {
-        outer1.outer_items.push_back(i + 5.0f);
-    }
+    const mymsgs::OuterMore_1_0 outer1(
+        {{1, 2, 3, 4}, pa},             // float32[<=8] outer_items
+        {                               // InnerMore.1.0[<=2] inners
+            {
+                {                           // InnerMore_1_0
+                    {{55, 66, 77}, pa},         // uint32[<=5] inner_items
+                    false,                      // bool inner_primitive
+                    pa
+                },
+                {                           // InnerMore_1_0
+                    {{88, 99}, pa},             // uint32[<=5] inner_items
+                    true,                       // bool inner_primitive
+                    pa
+                }
+            },
+            pa
+        },
+        777777,                         // int64 outer_primitive
+        pa
+    );
 
     // Serialize it
-    std::array<unsigned char, mymsgs::Outer_1_0::_traits_::SerializationBufferSizeBytes> roundtrip_buffer{};
+    std::array<unsigned char, mymsgs::OuterMore_1_0::_traits_::SerializationBufferSizeBytes> roundtrip_buffer{};
     nunavut::support::bitspan ser_buffer(roundtrip_buffer);
     const auto ser_result = serialize(outer1, ser_buffer);
     ASSERT_TRUE(ser_result);
 
     // Deserialize it
-    mymsgs::Outer_1_0 outer2{pa};
+    mymsgs::OuterMore_1_0 outer2{pa};
     nunavut::support::const_bitspan des_buffer(static_cast<const unsigned char*>(roundtrip_buffer.data()), roundtrip_buffer.size());
     const auto des_result = deserialize(outer2, des_buffer);
     ASSERT_TRUE(des_result);
 
     // Verify that the messages match
-    for (std::uint32_t i = 0; i < 5; i++) {
-        ASSERT_EQ(outer1.inner.inner_items[i], outer2.inner.inner_items[i]);
-    }
-    for (std::uint32_t i = 0; i < 8; i++) {
-        ASSERT_EQ(outer1.outer_items[i], outer2.outer_items[i]);
-    }
+    ASSERT_EQ(outer2.outer_items.size(), 4);
+    ASSERT_EQ(outer2.outer_items[0], 1);
+    ASSERT_EQ(outer2.outer_items[1], 2);
+    ASSERT_EQ(outer2.outer_items[2], 3);
+    ASSERT_EQ(outer2.outer_items[3], 4);
+    ASSERT_EQ(outer2.inners.size(), 2);
+    ASSERT_EQ(outer2.inners[0].inner_items.size(), 3);
+    ASSERT_EQ(outer2.inners[0].inner_items[0], 55);
+    ASSERT_EQ(outer2.inners[0].inner_items[1], 66);
+    ASSERT_EQ(outer2.inners[0].inner_items[2], 77);
+    ASSERT_EQ(outer2.inners[0].inner_primitive, false);
+    ASSERT_EQ(outer2.inners[1].inner_items.size(), 2);
+    ASSERT_EQ(outer2.inners[1].inner_items[0], 88);
+    ASSERT_EQ(outer2.inners[1].inner_items[1], 99);
+    ASSERT_EQ(outer2.inners[1].inner_primitive, true);
+    ASSERT_EQ(outer2.outer_primitive, 777777);
+
 }

--- a/verification/nunavut_test_types/nested_array_types/mymsgs/InnerMore.1.0.dsdl
+++ b/verification/nunavut_test_types/nested_array_types/mymsgs/InnerMore.1.0.dsdl
@@ -1,0 +1,3 @@
+uint32[<=5] inner_items
+bool inner_primitive
+@sealed

--- a/verification/nunavut_test_types/nested_array_types/mymsgs/OuterMore.1.0.dsdl
+++ b/verification/nunavut_test_types/nested_array_types/mymsgs/OuterMore.1.0.dsdl
@@ -1,0 +1,4 @@
+float32[<=8] outer_items
+InnerMore.1.0[<=2] inners
+int64 outer_primitive
+@sealed

--- a/verification/nunavut_test_types/nested_array_types/mymsgs/Simple.1.0.dsdl
+++ b/verification/nunavut_test_types/nested_array_types/mymsgs/Simple.1.0.dsdl
@@ -1,0 +1,4 @@
+int32 a
+float16 b
+bool c
+@sealed


### PR DESCRIPTION
… bug

When you use "cetl++14-17" or "c++17-pmr" we code-gen message classes with constructors that take an allocator.  Since the class has a user-defined constructor this means it can no longer use aggregate initialization (https://en.cppreference.com/w/cpp/language/aggregate_initialization) This is inconvenient so I'm adding a constructor with args for each field, in order.  This also makes it possible to declare a const message instance.

Some single arg constructors weren't marked explicit, thus becoming user-defined conversion functions, which introduces unexpected bugs. I've fixed all the constructors so any single-arg ones are declared explicit.

Fixed a deserialization bug where the allocator was not getting passed to a temporary.