### PR TITLE
cpp: relocate the deprecated attribute to fix clang compilation (#299)

### DIFF
--- a/src/nunavut/_version.py
+++ b/src/nunavut/_version.py
@@ -8,7 +8,7 @@
 .. autodata:: __version__
 """
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __license__ = "MIT"
 __author__ = "OpenCyphal"
 __copyright__ = "Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. Copyright (c) 2023 OpenCyphal."

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -28,10 +28,10 @@
 // +-------------------------------------------------------------------------------------------------------------------+
 {% endifuses -%}
 {{ composite_type.doc | block_comment('cpp-doxygen', 0, 120) }}
-{% if composite_type.deprecated -%}
+struct {% if composite_type.deprecated -%}
 [[deprecated("{{ composite_type }} is reaching the end of its life; there may be a newer version available")]]
-{% endif -%}
-struct {{composite_type|short_reference_name}} final
+{%- endif -%}
+{{composite_type|short_reference_name}} final
 {
     struct _traits_  // The name is surrounded with underscores to avoid collisions with DSDL attributes.
     {


### PR DESCRIPTION
Please review the syntax, I'm no Jinja expert. See #299 for explanation.