### PR TITLE
Reverted usage of select_on_container_copy_construction()

### DIFF
--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -80,7 +80,7 @@ namespace nunavut
 namespace support
 {
 
-template<typename T>
+template <typename T>
 class span final{
     T* ptr_;
     {{ typename_unsigned_length }} size_;

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -930,13 +930,13 @@ inline {{typename_float_64}} const_bitspan::getF64()
     return tmp.fl;
 }
 
-template <typename T>
-void assignInplace(T& dst, T&& src)
+template<typename T>
+void assignInplace(T& dst, const T& src)
 {
     // Intentional violation of MISRA cpp:M23_329: "Advanced memory management shall not be used".
     // This method is used to copy-assign objects in-place (like PMR allocators). It is safe and efficient.
     dst.~T();  // NOLINT NOSONAR
-    new (&dst) T(std::forward<T>(src));
+    new (&dst) T(src);
 }
 
 {% endif -%}

--- a/src/nunavut/lang/cpp/support/serialization.j2
+++ b/src/nunavut/lang/cpp/support/serialization.j2
@@ -80,7 +80,7 @@ namespace nunavut
 namespace support
 {
 
-template <typename T>
+template<typename T>
 class span final{
     T* ptr_;
     {{ typename_unsigned_length }} size_;

--- a/src/nunavut/lang/cpp/templates/_composite_type.j2
+++ b/src/nunavut/lang/cpp/templates/_composite_type.j2
@@ -114,7 +114,7 @@ struct {% if composite_type.deprecated -%}
     {%- if composite_type.inner_type is UnionType %}
         : union_value{}
         {%- if not composite_type.bit_length_set.fixed_length %}
-        , allocator_{allocator.select_on_container_copy_construction()}
+        , allocator_{allocator}
         {%- endif %}
     {%- else %}
     {%- for field in composite_type.fields_except_padding %}
@@ -153,7 +153,7 @@ struct {% if composite_type.deprecated -%}
     {%- if composite_type.inner_type is UnionType %}
         : union_value{rhs.union_value}
         {%- if not composite_type.bit_length_set.fixed_length %}
-        , allocator_{allocator.select_on_container_copy_construction()}
+        , allocator_{allocator}
         {%- endif %}
     {%- else %}
     {%- for field in composite_type.fields_except_padding %}
@@ -174,7 +174,7 @@ struct {% if composite_type.deprecated -%}
     {%- if composite_type.inner_type is UnionType %}
         : union_value{}
         {%- if not composite_type.bit_length_set.fixed_length %}
-        , allocator_{allocator.select_on_container_copy_construction()}
+        , allocator_{allocator}
         {%- endif %}
     {%- else %}
     {%- for field in composite_type.fields_except_padding %}
@@ -193,7 +193,7 @@ struct {% if composite_type.deprecated -%}
     {
         if (this != &rhs)
         {
-            nunavut::support::assignInplace(allocator_, rhs.allocator_.select_on_container_copy_construction());
+            nunavut::support::assignInplace(allocator_, rhs.allocator_);
             union_value = rhs.union_value;
         }
         return *this;
@@ -202,7 +202,7 @@ struct {% if composite_type.deprecated -%}
     // Move assignment
     {{composite_type|short_reference_name}}& operator=({{composite_type|short_reference_name}}&& rhs)
     {
-        nunavut::support::assignInplace(allocator_, rhs.allocator_.select_on_container_copy_construction());
+        nunavut::support::assignInplace(allocator_, std::move(rhs.allocator_));
         union_value = std::move(rhs.union_value);
         return *this;
     }


### PR DESCRIPTION
Reverted usage of `select_on_container_copy_construction()` - it broke libcyphal unit tests where there are unit tests which verify that there is no usage of the default PMR.

`select_on_container_copy_construction()` does exactly this - it create a completely new instance of allocator:
- without transferring underlining memory resource
- but instead getting the default `pmr::memory_resource()`