### PR TITLE
Fix for "garbage" bits

### DIFF
--- a/src/nunavut/lang/c/support/serialization.j2
+++ b/src/nunavut/lang/c/support/serialization.j2
@@ -182,7 +182,8 @@ static inline void nunavutCopyBits(void* const dst,
             const uint8_t mask = (uint8_t)((1U << length_mod) - 1U);
             // No lint for "The left operand of '&' is a garbage value" because
             // these so called "garbage" bits of `*last_dst` won't be used during deserialization.
-            *last_dst = (*last_dst & (uint8_t)~mask) | (*last_src & mask);  // NOLINT
+            // NOLINTNEXTLINE(clang-analyzer-core.UndefinedBinaryOperatorResult)
+            *last_dst = (*last_dst & (uint8_t)~mask) | (*last_src & mask);
         }
     }
     else

--- a/src/nunavut/lang/c/support/serialization.j2
+++ b/src/nunavut/lang/c/support/serialization.j2
@@ -180,7 +180,9 @@ static inline void nunavutCopyBits(void* const dst,
             uint8_t* const last_dst       = pdst + length_bytes;  // NOLINT NOSONAR
             {{ assert('length_mod < 8U') }}
             const uint8_t mask = (uint8_t)((1U << length_mod) - 1U);
-            *last_dst = (*last_dst & (uint8_t)~mask) | (*last_src & mask);
+            // No lint for "The left operand of '&' is a garbage value" because
+            // these so called "garbage" bits of `*last_dst` won't be used during deserialization.
+            *last_dst = (*last_dst & (uint8_t)~mask) | (*last_src & mask);  // NOLINT
         }
     }
     else


### PR DESCRIPTION
Small fix for clang-tidy false positive about using garbage data during serialization, like following:
```
/home/runner/work/demos/demos/libudpard_demo/build/transpiled/nunavut/support/serialization.h:154:36: error: The left operand of '&' is a garbage value [clang-analyzer-core.UndefinedBinaryOperatorResult,-warnings-as-errors]
            *last_dst = (*last_dst & (uint8_t)~mask) | (*last_src & mask);
                                   ^
```